### PR TITLE
fix: guard against zero-address swap targets on mainnet (#247)

### DIFF
--- a/packages/frontend/src/lib/direct-swap.ts
+++ b/packages/frontend/src/lib/direct-swap.ts
@@ -137,7 +137,10 @@ export async function fetchDirectQuote(
 ): Promise<DirectQuote> {
   const cfg = CHAIN_CONFIG[chainId]
   if (!cfg) throw new Error(`Unsupported chain ${chainId}`)
-  if (!cfg.daodegenToken) throw new Error('Mainnet addresses not yet configured')
+  if (!cfg.daodegenToken || cfg.daodegenToken === ADDRESS_ZERO)
+    throw new Error('Token address not yet configured for this chain')
+  if (!cfg.daodegenHook || cfg.daodegenHook === ADDRESS_ZERO)
+    throw new Error('Hook address not yet configured for this chain')
 
   let sqrtPriceX96: bigint
   let liquidity: bigint
@@ -208,6 +211,11 @@ export function buildSwapCalldata(
   amountOutMin: bigint,
   deadlineSecs: number,
 ): { to: `0x${string}`; data: `0x${string}`; value: bigint } {
+  if (!cfg.daodegenToken || cfg.daodegenToken === ADDRESS_ZERO)
+    throw new Error('Token address not yet configured for this chain')
+  if (!cfg.daodegenHook || cfg.daodegenHook === ADDRESS_ZERO)
+    throw new Error('Hook address not yet configured for this chain')
+
   const poolKey = buildPoolKey(cfg)
 
   const actions = encodePacked(


### PR DESCRIPTION
## Summary
Adds explicit ADDRESS_ZERO guards in `direct-swap.ts` for both `fetchDirectQuote` and `buildSwapCalldata`.

## Problem
Mainnet (chainId 130) token/hook addresses were set to `0x000...000`. The existing falsy check passed because zero-address is a truthy string. Swaps would send ETH to the UniversalRouter targeting zero-address tokens — **funds would be lost**.

## Fix
- Check both `!cfg.daodegenToken` and `cfg.daodegenToken === ADDRESS_ZERO`
- Same for `cfg.daodegenHook`
- Throws clear error if addresses aren't configured

Closes #247