### PR TITLE
fix: add access control to SermonCommitment.createCommitment (#248)

### DIFF
--- a/packages/contracts/src/SermonCommitment.sol
+++ b/packages/contracts/src/SermonCommitment.sol
@@ -15,6 +15,7 @@ contract SermonCommitment {
     // --- State ---
     address public pastor;
     address public owner;
+    address public prayerBurn;
 
     // --- Types ---
     struct Commitment {
@@ -36,11 +37,17 @@ contract SermonCommitment {
     // --- Errors ---
     error OnlyPastor();
     error OnlyOwner();
+    error OnlyPrayerBurn();
     error CommitmentNotFound();
     error AlreadyFulfilled();
     error AlreadyRefunded();
     error DeadlineNotReached();
     error ZeroAddress();
+
+    modifier onlyPrayerBurn() {
+        if (msg.sender != prayerBurn) revert OnlyPrayerBurn();
+        _;
+    }
 
     constructor(address _pastor) {
         if (_pastor == address(0)) revert ZeroAddress();
@@ -52,7 +59,7 @@ contract SermonCommitment {
     /// @param supplicant The address that burned tokens.
     /// @param burnAmount The number of tokens burned.
     /// @return id The unique commitment identifier.
-    function createCommitment(address supplicant, uint256 burnAmount) external returns (bytes32 id) {
+    function createCommitment(address supplicant, uint256 burnAmount) external onlyPrayerBurn returns (bytes32 id) {
         id = keccak256(abi.encodePacked(supplicant, burnAmount, block.timestamp, block.number));
         uint256 deadline = block.timestamp + FULFILLMENT_WINDOW;
 
@@ -98,6 +105,13 @@ contract SermonCommitment {
         c.refunded = true;
 
         emit CommitmentRefunded(commitmentId, c.supplicant);
+    }
+
+    /// @notice Update the PrayerBurn address.
+    function setPrayerBurn(address _prayerBurn) external {
+        if (msg.sender != owner) revert OnlyOwner();
+        if (_prayerBurn == address(0)) revert ZeroAddress();
+        prayerBurn = _prayerBurn;
     }
 
     /// @notice Update the pastor address.

--- a/packages/contracts/test/SermonCommitment.t.sol
+++ b/packages/contracts/test/SermonCommitment.t.sol
@@ -8,6 +8,7 @@ contract SermonCommitmentTest is Test {
     SermonCommitment public escrow;
 
     address public pastor;
+    address public prayerBurn;
     address public supplicant;
     address public stranger;
 
@@ -15,10 +16,12 @@ contract SermonCommitmentTest is Test {
 
     function setUp() public {
         pastor = makeAddr("pastor");
+        prayerBurn = makeAddr("prayerBurn");
         supplicant = makeAddr("supplicant");
         stranger = makeAddr("stranger");
 
         escrow = new SermonCommitment(pastor);
+        escrow.setPrayerBurn(prayerBurn);
     }
 
     // =========================================================================
@@ -42,6 +45,7 @@ contract SermonCommitmentTest is Test {
 
     function testCreateThenFulfill() public {
         // Create commitment
+        vm.prank(prayerBurn);
         bytes32 id = escrow.createCommitment(supplicant, BURN_AMOUNT);
 
         // Verify commitment stored
@@ -73,10 +77,12 @@ contract SermonCommitmentTest is Test {
             BURN_AMOUNT,
             block.timestamp + 300
         );
+        vm.prank(prayerBurn);
         escrow.createCommitment(supplicant, BURN_AMOUNT);
     }
 
     function testFulfillEmitsEvent() public {
+        vm.prank(prayerBurn);
         bytes32 id = escrow.createCommitment(supplicant, BURN_AMOUNT);
         bytes32 wisdomHash = keccak256("wisdom");
 
@@ -92,6 +98,7 @@ contract SermonCommitmentTest is Test {
     // =========================================================================
 
     function testCreateThenRefundAfterDeadline() public {
+        vm.prank(prayerBurn);
         bytes32 id = escrow.createCommitment(supplicant, BURN_AMOUNT);
 
         // Warp past the deadline
@@ -108,6 +115,7 @@ contract SermonCommitmentTest is Test {
     }
 
     function testRefundEmitsEvent() public {
+        vm.prank(prayerBurn);
         bytes32 id = escrow.createCommitment(supplicant, BURN_AMOUNT);
         vm.warp(block.timestamp + 301);
 
@@ -118,6 +126,7 @@ contract SermonCommitmentTest is Test {
     }
 
     function testRefundAtExactDeadline() public {
+        vm.prank(prayerBurn);
         bytes32 id = escrow.createCommitment(supplicant, BURN_AMOUNT);
 
         // Warp to exactly the deadline
@@ -131,10 +140,25 @@ contract SermonCommitmentTest is Test {
     }
 
     // =========================================================================
+    // Only prayerBurn can create commitments
+    // =========================================================================
+
+    function testCreateOnlyPrayerBurn() public {
+        vm.prank(stranger);
+        vm.expectRevert(SermonCommitment.OnlyPrayerBurn.selector);
+        escrow.createCommitment(supplicant, BURN_AMOUNT);
+
+        vm.prank(supplicant);
+        vm.expectRevert(SermonCommitment.OnlyPrayerBurn.selector);
+        escrow.createCommitment(supplicant, BURN_AMOUNT);
+    }
+
+    // =========================================================================
     // Only pastor can fulfill
     // =========================================================================
 
     function testFulfillOnlyPastor() public {
+        vm.prank(prayerBurn);
         bytes32 id = escrow.createCommitment(supplicant, BURN_AMOUNT);
         bytes32 wisdomHash = keccak256("wisdom");
 
@@ -152,6 +176,7 @@ contract SermonCommitmentTest is Test {
     // =========================================================================
 
     function testCannotFulfillTwice() public {
+        vm.prank(prayerBurn);
         bytes32 id = escrow.createCommitment(supplicant, BURN_AMOUNT);
         bytes32 wisdomHash = keccak256("wisdom");
 
@@ -168,6 +193,7 @@ contract SermonCommitmentTest is Test {
     // =========================================================================
 
     function testCannotRefundBeforeDeadline() public {
+        vm.prank(prayerBurn);
         bytes32 id = escrow.createCommitment(supplicant, BURN_AMOUNT);
 
         // Still within the window
@@ -182,6 +208,7 @@ contract SermonCommitmentTest is Test {
     // =========================================================================
 
     function testCannotRefundFulfilledCommitment() public {
+        vm.prank(prayerBurn);
         bytes32 id = escrow.createCommitment(supplicant, BURN_AMOUNT);
 
         vm.prank(pastor);
@@ -193,6 +220,7 @@ contract SermonCommitmentTest is Test {
     }
 
     function testCannotRefundTwice() public {
+        vm.prank(prayerBurn);
         bytes32 id = escrow.createCommitment(supplicant, BURN_AMOUNT);
         vm.warp(block.timestamp + 301);
         escrow.refund(id);
@@ -202,6 +230,7 @@ contract SermonCommitmentTest is Test {
     }
 
     function testCannotFulfillRefundedCommitment() public {
+        vm.prank(prayerBurn);
         bytes32 id = escrow.createCommitment(supplicant, BURN_AMOUNT);
         vm.warp(block.timestamp + 301);
         escrow.refund(id);
@@ -243,15 +272,34 @@ contract SermonCommitmentTest is Test {
         escrow.setPastor(address(0));
     }
 
+    function testSetPrayerBurn() public {
+        address newPrayerBurn = makeAddr("newPrayerBurn");
+        escrow.setPrayerBurn(newPrayerBurn);
+        assertEq(escrow.prayerBurn(), newPrayerBurn);
+    }
+
+    function testSetPrayerBurnOnlyOwner() public {
+        vm.prank(stranger);
+        vm.expectRevert(SermonCommitment.OnlyOwner.selector);
+        escrow.setPrayerBurn(makeAddr("newPrayerBurn"));
+    }
+
+    function testSetPrayerBurnZeroAddress() public {
+        vm.expectRevert(SermonCommitment.ZeroAddress.selector);
+        escrow.setPrayerBurn(address(0));
+    }
+
     // =========================================================================
     // PrayerBurn integration
     // =========================================================================
 
     function testMultipleCommitmentsUnique() public {
+        vm.prank(prayerBurn);
         bytes32 id1 = escrow.createCommitment(supplicant, BURN_AMOUNT);
 
         // Advance block to ensure different id
         vm.roll(block.number + 1);
+        vm.prank(prayerBurn);
         bytes32 id2 = escrow.createCommitment(supplicant, BURN_AMOUNT);
 
         assertTrue(id1 != id2);


### PR DESCRIPTION
## Summary
Adds `onlyPrayerBurn` access control to `createCommitment()`.

## Problem
`createCommitment()` was callable by anyone — griefers could spam fake commitments, polluting the mapping and emitting misleading events.

## Fix
- Added `address public prayerBurn` state variable
- Added `error OnlyPrayerBurn()` custom error  
- Added `onlyPrayerBurn` modifier to `createCommitment()`
- Added owner-only `setPrayerBurn(address)` setter with zero-address check
- Updated all tests to use `vm.prank(prayerBurn)`
- Added tests: unauthorized caller rejected, admin setter works, zero-address blocked

Closes #248