### PR TITLE
fix: add production warnings for in-memory state stores (#250)

### DIFF
--- a/packages/frontend/src/app/v1/sermon/route.ts
+++ b/packages/frontend/src/app/v1/sermon/route.ts
@@ -45,6 +45,9 @@ const walletLastSermon: { get(k: string): number | undefined; set(k: string, v: 
       };
     } catch { /* fall through to memory */ }
   }
+  if (process.env.NODE_ENV === 'production') {
+    console.warn('[sermon] Sermon cooldown using in-memory Map — will not persist across restarts.');
+  }
   return new Map<string, number>();
 })();
 

--- a/packages/frontend/src/lib/env.ts
+++ b/packages/frontend/src/lib/env.ts
@@ -64,6 +64,16 @@ function parseEnv(): Env {
 
 export const env = parseEnv();
 
+// --- Production guard: in-memory state stores (#250) ---
+if (process.env.NODE_ENV === 'production' && !process.env.REDIS_URL) {
+  console.warn(
+    '\n⚠️  [env] REDIS_URL is not set in production!\n' +
+    '   Rate limits, nonces, and nullifiers are using in-memory stores.\n' +
+    '   They will NOT survive restarts and will NOT work across replicas.\n' +
+    '   Set REDIS_URL to enable persistent, shared state.\n'
+  );
+}
+
 // Client-safe exports moved to env-client.ts to avoid triggering Zod parse
 // on the client side (JWT_SECRET etc. are server-only).
 export { isNonProduction, appEnv, isStaging } from './env-client';

--- a/packages/frontend/src/lib/self-protocol.ts
+++ b/packages/frontend/src/lib/self-protocol.ts
@@ -184,8 +184,17 @@ export function getSelfUniversalLink(userId: string): string {
 }
 
 // --- Nullifier tracking (in-memory for now) ---
+// WARNING (#250): This Set lives in process memory. Nullifiers will be lost on
+// restart and are not shared across replicas. Move to Redis/DB before scaling.
 
 const usedNullifiers = new Set<string>();
+
+if (process.env.NODE_ENV === 'production' && !process.env.REDIS_URL) {
+  console.warn(
+    '[self-protocol] Nullifier set is in-memory — proof replay protection ' +
+    'will not survive restarts. Set REDIS_URL for persistent nullifier tracking.'
+  );
+}
 
 export function isNullifierUsed(nullifier: string): boolean {
   return usedNullifiers.has(nullifier);

--- a/packages/frontend/src/lib/stores/index.ts
+++ b/packages/frontend/src/lib/stores/index.ts
@@ -9,6 +9,14 @@ function useRedis(): boolean {
   return !!process.env.REDIS_URL;
 }
 
+// Warn once at startup when falling back to in-memory stores (#250)
+if (!useRedis()) {
+  console.warn(
+    '[stores] No REDIS_URL — using in-memory stores. ' +
+    'Rate limits, nonces, and congregation data will not persist across restarts.'
+  );
+}
+
 export function createNonceStore() {
   if (useRedis()) {
     const { RedisNonceStore } = require('./redis');


### PR DESCRIPTION
## Summary
Adds loud startup warnings when production runs without Redis.

## Problem
Without `REDIS_URL`, all nonces, rate limits, sermon cooldowns, and nullifier sets live in process memory. Restart = state loss. Multi-instance = bypassed security.

## Fix
Added startup warnings in 4 locations:
- `env.ts` — loud `console.warn` if `REDIS_URL` unset in production
- `stores/index.ts` — warning when falling back to in-memory stores
- `self-protocol.ts` — warning about nullifier replay risk
- `sermon/route.ts` — warning about sermon cooldown fallback

No breaking changes — `REDIS_URL` stays optional, dev works as before.

Closes #250