### PR TITLE
fix: guard zero-address mainnet swap — prevents fund loss (#247)

### DIFF
--- a/packages/frontend/src/lib/direct-swap.ts
+++ b/packages/frontend/src/lib/direct-swap.ts
@@ -137,7 +137,9 @@ export async function fetchDirectQuote(
 ): Promise<DirectQuote> {
   const cfg = CHAIN_CONFIG[chainId]
   if (!cfg) throw new Error(`Unsupported chain ${chainId}`)
-  if (!cfg.daodegenToken) throw new Error('Mainnet addresses not yet configured')
+  if (cfg.daodegenToken === ADDRESS_ZERO || cfg.daodegenHook === ADDRESS_ZERO) {
+    throw new Error('Mainnet swap not yet available — contract addresses not configured')
+  }
 
   let sqrtPriceX96: bigint
   let liquidity: bigint
@@ -208,6 +210,10 @@ export function buildSwapCalldata(
   amountOutMin: bigint,
   deadlineSecs: number,
 ): { to: `0x${string}`; data: `0x${string}`; value: bigint } {
+  if (cfg.daodegenToken === ADDRESS_ZERO || cfg.daodegenHook === ADDRESS_ZERO) {
+    throw new Error('Mainnet swap not yet available — contract addresses not configured')
+  }
+
   const poolKey = buildPoolKey(cfg)
 
   const actions = encodePacked(


### PR DESCRIPTION
Adds explicit runtime guard in direct-swap.ts: if daodegenToken or daodegenHook is zero-address, throw a clear error instead of silently sending a transaction to 0x000.

Mainnet contracts are not yet deployed; this makes that state safe and obvious.

Closes #247