### PR TITLE
fix: CORS — fail loudly at startup if FRONTEND_ORIGIN unset in production (#252)

### DIFF
--- a/packages/facilitator/.env.example
+++ b/packages/facilitator/.env.example
@@ -6,3 +6,6 @@ FACILITATOR_PORT=4402
 
 # Unichain Sepolia RPC URL (default: https://sepolia.unichain.org)
 UNICHAIN_SEPOLIA_RPC=https://sepolia.unichain.org
+
+# Origin allowed by CORS (required in production, e.g. https://daodegen.xyz)
+FRONTEND_ORIGIN=https://daodegen.xyz

--- a/packages/facilitator/src/index.ts
+++ b/packages/facilitator/src/index.ts
@@ -103,6 +103,14 @@ console.log(`Supported:`, JSON.stringify(facilitator.getSupported(), null, 2));
 
 const isDev = process.env.NODE_ENV !== 'production';
 
+if (!isDev && !process.env.FRONTEND_ORIGIN) {
+  console.error(
+    "FATAL: FRONTEND_ORIGIN must be set in production (e.g. https://daodegen.xyz). " +
+    "Without it, CORS will reject every cross-origin request.",
+  );
+  process.exit(1);
+}
+
 const ALLOWED_ORIGINS = new Set([
   ...(isDev ? ["http://localhost:3033", "http://localhost:3031"] : []),
   process.env.FRONTEND_ORIGIN,


### PR DESCRIPTION
Previously, missing FRONTEND_ORIGIN in production silently resulted in an empty allowed-origins list, rejecting all cross-origin requests.

Fix: throw a startup error if NODE_ENV=production and FRONTEND_ORIGIN is not set. Misconfiguration now fails fast and loud instead of silently.

Also adds FRONTEND_ORIGIN to .env.example.

Closes #252