### PR TITLE
fix: always emit PrayerBurned event regardless of SermonCommitment config (#254)

### DIFF
--- a/packages/contracts/src/PrayerBurn.sol
+++ b/packages/contracts/src/PrayerBurn.sol
@@ -93,6 +93,7 @@ contract PrayerBurn is Ownable, ReentrancyGuard {
 
         // Create sermon commitment if escrow is configured.
         // Non-fatal: if SermonCommitment reverts for any reason, burn proceeds without escrow.
+        // When sermonCommitment is not configured, commitmentId remains bytes32(0).
         bytes32 commitmentId;
         if (address(sermonCommitment) != address(0)) {
             try sermonCommitment.createCommitment(msg.sender, amount) returns (bytes32 id) {
@@ -100,8 +101,8 @@ contract PrayerBurn is Ownable, ReentrancyGuard {
             } catch {
                 // SermonCommitment failure is non-fatal — burn proceeds, commitment skipped
             }
-            emit PrayerBurned(msg.sender, amount, commitmentId);
         }
+        emit PrayerBurned(msg.sender, amount, commitmentId);
 
         _tryRelease();
     }

--- a/packages/contracts/test/PrayerBurn.t.sol
+++ b/packages/contracts/test/PrayerBurn.t.sol
@@ -98,6 +98,19 @@ contract PrayerBurnTest is Test {
         vm.stopPrank();
     }
 
+    function testPrayEmitsPrayerBurnedWithoutSermonCommitment() public {
+        uint256 amount = 100e18;
+        bytes memory message = "test prayer";
+
+        vm.startPrank(user1);
+        token.approve(address(prayer), amount);
+
+        vm.expectEmit(true, false, false, true);
+        emit PrayerBurn.PrayerBurned(user1, amount, bytes32(0));
+        prayer.pray(amount, message);
+        vm.stopPrank();
+    }
+
     function testPraySilentBurn() public {
         vm.startPrank(user1);
         token.approve(address(prayer), MINIMUM_BURN);


### PR DESCRIPTION
PrayerBurned was only emitted when sermonCommitment was configured. Indexers and frontends listening for this event would miss burns when the escrow integration is disabled.

Fix: always emit PrayerBurned after a successful burn. Uses bytes32(0) as commitmentId when SermonCommitment is not set.

Closes #254