### PR TITLE
fix: DaoDeGenJar.release() — remainder goes to last NFT not first (#251)

### DIFF
--- a/packages/contracts/src/DaoDeGenJar.sol
+++ b/packages/contracts/src/DaoDeGenJar.sol
@@ -101,15 +101,12 @@ contract DaoDeGenJar is Ownable, ReentrancyGuard, Pausable {
             uint256 remainder = distributable % totalNFTs;
 
             uint256 totalDistributed = 0;
-            bool first = true;
             for (uint256 j = 0; j < totalNFTs; j++) {
                 uint256 tokenId = nft.tokenByIndex(j);
                 uint256 amount = perHolder;
 
-                if (first && remainder > 0) {
+                if (j == totalNFTs - 1 && remainder > 0) {
                     amount += remainder;
-                    remainder = 0;
-                    first = false;
                 }
 
                 if (amount > 0) {

--- a/packages/contracts/test/DaoDeGenJar.t.sol
+++ b/packages/contracts/test/DaoDeGenJar.t.sol
@@ -475,9 +475,9 @@ contract DaoDeGenJarTest is Test {
         jar.release(assets);
         vm.stopPrank();
         
-        // user1 (ID 1) should get 1 + 1 (remainder) = 2
-        // user2 (ID 2) should get 1
-        assertEq(jar.claimable(1, assets[0]), 2);
-        assertEq(jar.claimable(2, assets[0]), 1);
+        // user1 (ID 1) should get 1
+        // user2 (ID 2) should get 1 + 1 (remainder) = 2
+        assertEq(jar.claimable(1, assets[0]), 1);
+        assertEq(jar.claimable(2, assets[0]), 2);
     }
 }


### PR DESCRIPTION
When distributing assets to NFT holders, integer division produces a remainder. Previously this always went to the first recipient (index 0), giving them a systematic advantage.

Fix: remainder is now added to the last recipient's share.

Closes #251