### PR TITLE
fix: configure Playwright E2E tests for Unichain mainnet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,12 @@ on:
   schedule:
     # Nightly at 06:00 UTC -- runs paid E2E flow against testnet
     - cron: '0 6 * * *'
+  workflow_dispatch:
+    inputs:
+      run_mainnet_e2e:
+        description: 'Run Visual QA against mainnet (0xdead.church)'
+        required: false
+        default: 'true'
 
 jobs:
   contracts:
@@ -119,11 +125,12 @@ jobs:
           FACILITATOR_PRIVATE_KEY: ${{ secrets.FACILITATOR_PRIVATE_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           E2E_PAYER_PRIVATE_KEY: ${{ secrets.E2E_PAYER_PRIVATE_KEY }}
-      - name: Run Visual QA tests
+      - name: Run Visual QA tests (localhost)
         run: npx playwright test --config=playwright.visual-qa.config.ts
         working-directory: packages/frontend
         env:
           CI: true
+          BASE_URL: 'http://localhost:3031'
       - name: Upload Playwright report
         if: failure()
         uses: actions/upload-artifact@v4
@@ -131,6 +138,37 @@ jobs:
           name: playwright-report
           path: packages/frontend/playwright-report/
           retention-days: 14
+
+  e2e-mainnet:
+    name: Visual QA (mainnet — 0xdead.church)
+    # Run on schedule (nightly) or manually via workflow_dispatch.
+    # Does NOT run on every PR to avoid hammering the live site.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm install
+      - name: Install Playwright chromium
+        run: npx playwright install --with-deps chromium
+        working-directory: packages/frontend
+      - name: Run Visual QA tests against mainnet
+        run: npx playwright test --config=playwright.visual-qa.config.ts
+        working-directory: packages/frontend
+        env:
+          CI: true
+          BASE_URL: 'https://0xdead.church'
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-mainnet
+          path: packages/frontend/playwright-report/
+          retention-days: 30
 
   verify-contracts:
     needs: [contracts]

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -10,6 +10,7 @@
     "test": "vitest run",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
+    "test:e2e:mainnet": "BASE_URL=https://0xdead.church npx playwright test --config=playwright.visual-qa.config.ts",
     "health-check": "node scripts/health-check.js"
   },
   "dependencies": {

--- a/packages/frontend/playwright.visual-qa.config.ts
+++ b/packages/frontend/playwright.visual-qa.config.ts
@@ -1,8 +1,39 @@
 import { defineConfig, devices } from '@playwright/test';
+import type { PlaywrightTestConfig } from '@playwright/test';
 
-// Visual QA config — only requires the frontend dev server.
-// The x402 payment API tests use the real server but gracefully handle 402s.
+// Visual QA config — runs the 7 visual-qa E2E specs.
+//
+// Targets the live mainnet deployment by default:
+//   BASE_URL=https://0xdead.church npx playwright test --config=playwright.visual-qa.config.ts
+//
+// To run against a local dev server instead:
+//   BASE_URL=http://localhost:3031 npx playwright test --config=playwright.visual-qa.config.ts
+//
 // Use: npx playwright test --config=playwright.visual-qa.config.ts
+
+const baseURL = process.env.BASE_URL || 'https://0xdead.church';
+
+// Only spin up a local web server when targeting localhost.
+// When BASE_URL points at mainnet (or any external host), skip the webServer block
+// so Playwright connects directly without trying to start Next.js.
+const isLocalhost = baseURL.includes('localhost') || baseURL.includes('127.0.0.1');
+
+const webServer: PlaywrightTestConfig['webServer'] = isLocalhost
+  ? {
+      command: 'npm run start',
+      url: baseURL,
+      reuseExistingServer: true,
+      env: {
+        NEXT_PUBLIC_VERSE_NFT_ADDRESS: '0x63d24FADFe2431462bc7cC362e8aE1E3f17fAf50',
+        NEXT_PUBLIC_DAODEGEN_TOKEN_ADDRESS: '0x9BbF24fDE364b328943ee2A21E818d6446Ff5a16',
+        NEXT_PUBLIC_DAODEGEN_JAR_ADDRESS: '0xd25a5C67F180811e43990B2A0148Ac0d93ab9336',
+        NEXT_PUBLIC_AGENT_REGISTRY_ADDRESS: '0x0000000000000000000000000000000000000000',
+        NEXT_PUBLIC_PRAYER_BURN_ADDRESS: '0x38C7AD96C2f5c90BE692605a7a7B633071122c72',
+        JWT_SECRET: 'e2e-test-secret',
+        FACILITATOR_URL: 'http://localhost:4402',
+      },
+    }
+  : undefined;
 
 export default defineConfig({
   testDir: './e2e',
@@ -13,13 +44,14 @@ export default defineConfig({
   workers: 1,
   // expect.timeout must be at root level (not inside use)
   expect: { timeout: 15000 },
-  reporter: 'list',
+  reporter: [['list'], ['html', { open: 'never' }]],
   use: {
-    baseURL: 'http://localhost:3031',
+    baseURL,
     trace: 'on-first-retry',
     // Pages with wagmi/RainbowKit hydration take up to 10s on first load
     actionTimeout: 15000,
-    navigationTimeout: 30000,
+    // Allow more time for mainnet requests (network latency + CDN)
+    navigationTimeout: 45000,
   },
   projects: [
     {
@@ -27,18 +59,5 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] },
     },
   ],
-  webServer: {
-    command: 'npm run start',
-    url: 'http://localhost:3031',
-    reuseExistingServer: true,
-    env: {
-      NEXT_PUBLIC_VERSE_NFT_ADDRESS: '0x63d24FADFe2431462bc7cC362e8aE1E3f17fAf50',
-      NEXT_PUBLIC_DAODEGEN_TOKEN_ADDRESS: '0x9BbF24fDE364b328943ee2A21E818d6446Ff5a16',
-      NEXT_PUBLIC_DAODEGEN_JAR_ADDRESS: '0xd25a5C67F180811e43990B2A0148Ac0d93ab9336',
-      NEXT_PUBLIC_AGENT_REGISTRY_ADDRESS: '0x0000000000000000000000000000000000000000',
-      NEXT_PUBLIC_PRAYER_BURN_ADDRESS: '0x38C7AD96C2f5c90BE692605a7a7B633071122c72',
-      JWT_SECRET: 'e2e-test-secret',
-      FACILITATOR_URL: 'http://localhost:4402',
-    },
-  },
+  ...(webServer ? { webServer } : {}),
 });


### PR DESCRIPTION
## Summary

Configures the Playwright Visual QA E2E test suite to run against the live Unichain mainnet deployment at https://0xdead.church.

## Changes

### `packages/frontend/playwright.visual-qa.config.ts`
- Read `BASE_URL` env var; default is now `https://0xdead.church` (was hardcoded `http://localhost:3031`)
- Skip the `webServer` block when `BASE_URL` points to an external host — Playwright connects directly, no local Next.js build needed
- Raised `navigationTimeout` to 45s (was 30s) to accommodate real-network latency on mainnet
- Added HTML reporter alongside list reporter

### `packages/frontend/package.json`
- Added `test:e2e:mainnet` script: `BASE_URL=https://0xdead.church npx playwright test --config=playwright.visual-qa.config.ts`

### `.github/workflows/ci.yml`
- Added `workflow_dispatch` trigger with `run_mainnet_e2e` input
- Existing `e2e` job now explicitly passes `BASE_URL=http://localhost:3031` so localhost behaviour is unchanged
- Added new `e2e-mainnet` job that runs the visual-qa suite directly against `https://0xdead.church` on nightly schedule and manual dispatch — no local build required
- Uploads Playwright report as artifact for 30 days (always, not just on failure)

## How to run

```bash
# Against mainnet (no local server needed)
npm run test:e2e:mainnet --workspace=packages/frontend

# Or directly
BASE_URL=https://0xdead.church npx playwright test --config packages/frontend/playwright.visual-qa.config.ts

# Against local server (unchanged behaviour)
BASE_URL=http://localhost:3031 npx playwright test --config packages/frontend/playwright.visual-qa.config.ts
```

## Notes
- The 7 visual-qa spec files use SSR `request.get()` checks and do not hardcode any URLs — they already rely on `baseURL` from config, so no spec changes were needed
- `visual-qa-172-wallet-connection.spec.ts` and `visual-qa-173-mint-nft.spec.ts` tests that involve actual on-chain wallet interactions will still require a funded wallet; the SSR-based tests should pass without one

Fixes 0xPotatoofdoom/daodegen#218