### PR TITLE
fix: health check validates active LLM provider, not just Anthropic key (#259)

### DIFF
--- a/packages/frontend/src/app/api/health/route.test.ts
+++ b/packages/frontend/src/app/api/health/route.test.ts
@@ -16,7 +16,7 @@ afterEach(() => {
 });
 
 describe('GET /api/health', () => {
-  it('returns ok when all checks pass', async () => {
+  it('returns ok when all checks pass (anthropic)', async () => {
     process.env.NEXT_PUBLIC_UNICHAIN_RPC = 'https://rpc.test.com';
     process.env.ANTHROPIC_API_KEY = 'sk-test-key';
 
@@ -29,8 +29,53 @@ describe('GET /api/health', () => {
     expect(body.status).toBe('ok');
     expect(body.checks.rpc.status).toBe('ok');
     expect(body.checks.rpc.latency_ms).toBeTypeOf('number');
-    expect(body.checks.anthropic.status).toBe('ok');
+    expect(body.checks.llm.status).toBe('ok');
+    expect(body.checks.llm.provider).toBe('anthropic');
     expect(body.timestamp).toBeTruthy();
+  });
+
+  it('returns ok with venice as active provider when venice key is set', async () => {
+    process.env.NEXT_PUBLIC_UNICHAIN_RPC = 'https://rpc.test.com';
+    process.env.VENICE_API_KEY = 'venice-test-key';
+
+    mockFetch.mockResolvedValue({ ok: true });
+
+    const { GET } = await import('./route');
+    const response = await GET();
+    const body = await response.json();
+
+    expect(body.status).toBe('ok');
+    expect(body.checks.llm.status).toBe('ok');
+    expect(body.checks.llm.provider).toBe('venice');
+  });
+
+  it('returns ok with bankr as active provider when bankr key is set', async () => {
+    process.env.NEXT_PUBLIC_UNICHAIN_RPC = 'https://rpc.test.com';
+    process.env.BANKR_API_KEY = 'bankr-test-key';
+
+    mockFetch.mockResolvedValue({ ok: true });
+
+    const { GET } = await import('./route');
+    const response = await GET();
+    const body = await response.json();
+
+    expect(body.status).toBe('ok');
+    expect(body.checks.llm.status).toBe('ok');
+    expect(body.checks.llm.provider).toBe('bankr');
+  });
+
+  it('prefers venice over anthropic (matches provider priority)', async () => {
+    process.env.NEXT_PUBLIC_UNICHAIN_RPC = 'https://rpc.test.com';
+    process.env.VENICE_API_KEY = 'venice-test-key';
+    process.env.ANTHROPIC_API_KEY = 'sk-test-key';
+
+    mockFetch.mockResolvedValue({ ok: true });
+
+    const { GET } = await import('./route');
+    const response = await GET();
+    const body = await response.json();
+
+    expect(body.checks.llm.provider).toBe('venice');
   });
 
   it('returns degraded when RPC returns non-ok status', async () => {
@@ -62,8 +107,10 @@ describe('GET /api/health', () => {
     expect(body.checks.rpc.error).toContain('Network unreachable');
   });
 
-  it('returns degraded when ANTHROPIC_API_KEY is missing', async () => {
+  it('returns degraded when no LLM provider key is set', async () => {
     delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.VENICE_API_KEY;
+    delete process.env.BANKR_API_KEY;
 
     mockFetch.mockResolvedValue({ ok: true });
 
@@ -72,12 +119,14 @@ describe('GET /api/health', () => {
     const body = await response.json();
 
     expect(body.status).toBe('degraded');
-    expect(body.checks.anthropic.status).toBe('fail');
-    expect(body.checks.anthropic.error).toContain('not set');
+    expect(body.checks.llm.status).toBe('fail');
+    expect(body.checks.llm.error).toContain('No LLM provider key set');
   });
 
   it('returns degraded when all checks fail', async () => {
     delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.VENICE_API_KEY;
+    delete process.env.BANKR_API_KEY;
 
     mockFetch.mockRejectedValue(new Error('timeout'));
 
@@ -87,6 +136,6 @@ describe('GET /api/health', () => {
 
     expect(body.status).toBe('degraded');
     expect(body.checks.rpc.status).toBe('fail');
-    expect(body.checks.anthropic.status).toBe('fail');
+    expect(body.checks.llm.status).toBe('fail');
   });
 });

--- a/packages/frontend/src/app/api/health/route.ts
+++ b/packages/frontend/src/app/api/health/route.ts
@@ -5,6 +5,7 @@ interface CheckResult {
   status: 'ok' | 'fail';
   latency_ms?: number;
   error?: string;
+  provider?: string;
 }
 
 async function checkRpc(): Promise<CheckResult> {
@@ -26,18 +27,31 @@ async function checkRpc(): Promise<CheckResult> {
   }
 }
 
+// Provider priority matches llm.ts: Venice → Bankr → Anthropic
+const LLM_PROVIDERS = [
+  { name: 'venice', envVar: 'VENICE_API_KEY' },
+  { name: 'bankr', envVar: 'BANKR_API_KEY' },
+  { name: 'anthropic', envVar: 'ANTHROPIC_API_KEY' },
+] as const;
 
-function checkAnthropic(): CheckResult {
-  return process.env.ANTHROPIC_API_KEY
-    ? { status: 'ok' }
-    : { status: 'fail', error: 'ANTHROPIC_API_KEY not set' };
+function checkLlmProvider(): CheckResult {
+  for (const { name, envVar } of LLM_PROVIDERS) {
+    if (process.env[envVar]) {
+      console.log(`[health] active LLM provider: ${name} (${envVar})`);
+      return { status: 'ok', provider: name };
+    }
+  }
+
+  const checked = LLM_PROVIDERS.map((p) => p.envVar).join(', ');
+  console.warn(`[health] no LLM provider key found (checked: ${checked})`);
+  return { status: 'fail', error: `No LLM provider key set (checked: ${checked})` };
 }
 
 export async function GET() {
   const rpc = await checkRpc();
-  const anthropic = checkAnthropic();
+  const llm = checkLlmProvider();
 
-  const checks = { rpc, anthropic };
+  const checks = { rpc, llm };
   const allOk = Object.values(checks).every((c) => c.status === 'ok');
 
   return NextResponse.json({


### PR DESCRIPTION
## Summary
- The `/api/health` endpoint was hardcoded to check `ANTHROPIC_API_KEY` regardless of which LLM provider is configured
- Health check now validates the key for whichever provider is active, using a priority list matching `llm.ts`: Venice → Bankr → Anthropic
- Reports the active provider name in the health response and lists all checked env vars on failure

## Test plan
- [x] Added tests for Venice and Bankr provider detection
- [x] Added test verifying provider priority (Venice preferred over Anthropic)
- [x] Updated existing tests to use generic `checks.llm` instead of `checks.anthropic`
- [x] Test for degraded status when no provider key is set now clears all provider keys

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)