### PR TITLE
fix: VerseNFT.withdraw() — only withdraw tracked mint proceeds, not full balance (#258)

### DIFF
--- a/packages/contracts/src/VerseNFT.sol
+++ b/packages/contracts/src/VerseNFT.sol
@@ -19,6 +19,7 @@ contract VerseNFT is ERC721Enumerable, Ownable, Pausable {
     uint256 public mintCooldown;
     string public baseTokenURI;
     uint256 private _nextTokenId = 1;
+    uint256 public withdrawable;
 
     mapping(address => uint256) public lastMintTimestamp;
 
@@ -63,6 +64,7 @@ contract VerseNFT is ERC721Enumerable, Ownable, Pausable {
         if (_nextTokenId > MAX_SUPPLY) revert MaxSupplyReached();
 
         lastMintTimestamp[msg.sender] = block.timestamp;
+        _addWithdrawable(msg.value);
         _safeMint(msg.sender, _nextTokenId);
         _nextTokenId++;
     }
@@ -111,6 +113,12 @@ contract VerseNFT is ERC721Enumerable, Ownable, Pausable {
     function unpause() external onlyOwner { _unpause(); }
 
     function withdraw() external onlyOwner {
-        Address.sendValue(payable(msg.sender), address(this).balance);
+        uint256 amount = withdrawable;
+        withdrawable = 0;
+        Address.sendValue(payable(msg.sender), amount);
+    }
+
+    function _addWithdrawable(uint256 amount) internal {
+        withdrawable += amount;
     }
 }

--- a/packages/contracts/test/VerseNFT.t.sol
+++ b/packages/contracts/test/VerseNFT.t.sol
@@ -176,6 +176,54 @@ contract VerseNFTTest is Test {
         uint256 finalBalance = address(this).balance;
 
         assertEq(finalBalance - initialBalance, price);
+        assertEq(verseNFT.withdrawable(), 0);
+    }
+
+    function testWithdrawOnlyDrainsTrackedAmount() public {
+        // Send extra ETH directly to contract (simulating protocol reserves)
+        vm.deal(address(verseNFT), 5 ether);
+
+        // Mint — only mint proceeds should be withdrawable
+        vm.deal(user1, 1 ether);
+        uint256 price = verseNFT.mintPrice();
+        vm.prank(user1);
+        verseNFT.mint{value: price}();
+
+        assertEq(verseNFT.withdrawable(), price);
+
+        uint256 initialBalance = address(this).balance;
+        verseNFT.withdraw();
+        uint256 finalBalance = address(this).balance;
+
+        // Owner receives only the mint proceeds, not the 5 ETH reserve
+        assertEq(finalBalance - initialBalance, price);
+        // Contract still holds the reserve
+        assertEq(address(verseNFT).balance, 5 ether);
+    }
+
+    function testWithdrawAccumulatesAcrossMints() public {
+        verseNFT.setMintCooldown(0);
+        vm.deal(user1, 100 ether);
+
+        uint256 price1 = verseNFT.mintPrice();
+        vm.prank(user1);
+        verseNFT.mint{value: price1}();
+
+        uint256 price2 = verseNFT.mintPrice();
+        vm.prank(user1);
+        verseNFT.mint{value: price2}();
+
+        assertEq(verseNFT.withdrawable(), price1 + price2);
+
+        uint256 initialBalance = address(this).balance;
+        verseNFT.withdraw();
+        assertEq(address(this).balance - initialBalance, price1 + price2);
+        assertEq(verseNFT.withdrawable(), 0);
+
+        // Second withdraw sends nothing
+        uint256 balBefore = address(this).balance;
+        verseNFT.withdraw();
+        assertEq(address(this).balance, balBefore);
     }
 
     function testTokenURI() public {


### PR DESCRIPTION
## Summary
- `withdraw()` previously sent `address(this).balance` to owner, draining any ETH held for other purposes
- Added `withdrawable` state variable that tracks only mint proceeds via internal `_addWithdrawable()` helper
- `withdraw()` now sends only the tracked `withdrawable` amount and resets it to 0

## Test plan
- [x] Existing `testWithdraw` passes — verifies owner receives mint proceeds
- [x] `testWithdrawOnlyDrainsTrackedAmount` — contract holds 5 ETH reserve + mint proceeds; withdraw only sends mint proceeds, reserve stays
- [x] `testWithdrawAccumulatesAcrossMints` — multiple mints accumulate; single withdraw sends total; second withdraw sends 0

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)