### PR TITLE
fix: track mintRevenue separately — withdraw() only pulls mint proceeds (#258)

### DIFF
--- a/packages/contracts/src/VerseNFT.sol
+++ b/packages/contracts/src/VerseNFT.sol
@@ -20,12 +20,15 @@ contract VerseNFT is ERC721Enumerable, Ownable, Pausable {
     string public baseTokenURI;
     uint256 private _nextTokenId = 1;
 
+    uint256 public mintRevenue;
+
     mapping(address => uint256) public lastMintTimestamp;
 
     error MaxSupplyReached();
     error InsufficientPayment();
     error InvalidTokenId();
     error MintCooldownActive();
+    error NothingToWithdraw();
 
     event BaseURIUpdated(string newBaseURI);
     event BaseMintPriceUpdated(uint256 newPrice);
@@ -63,6 +66,7 @@ contract VerseNFT is ERC721Enumerable, Ownable, Pausable {
         if (_nextTokenId > MAX_SUPPLY) revert MaxSupplyReached();
 
         lastMintTimestamp[msg.sender] = block.timestamp;
+        mintRevenue += msg.value;
         _safeMint(msg.sender, _nextTokenId);
         _nextTokenId++;
     }
@@ -111,6 +115,9 @@ contract VerseNFT is ERC721Enumerable, Ownable, Pausable {
     function unpause() external onlyOwner { _unpause(); }
 
     function withdraw() external onlyOwner {
-        Address.sendValue(payable(msg.sender), address(this).balance);
+        uint256 amount = mintRevenue;
+        if (amount == 0) revert NothingToWithdraw();
+        mintRevenue = 0;
+        Address.sendValue(payable(msg.sender), amount);
     }
 }

--- a/packages/contracts/test/VerseNFT.t.sol
+++ b/packages/contracts/test/VerseNFT.t.sol
@@ -176,6 +176,57 @@ contract VerseNFTTest is Test {
         uint256 finalBalance = address(this).balance;
 
         assertEq(finalBalance - initialBalance, price);
+        assertEq(verseNFT.mintRevenue(), 0);
+    }
+
+    function testWithdrawOnlyMintRevenue() public {
+        // Mint to accumulate revenue
+        vm.deal(user1, 1 ether);
+        uint256 price = verseNFT.mintPrice();
+        vm.prank(user1);
+        verseNFT.mint{value: price}();
+
+        // Force-send extra ETH via selfdestruct (simulates stray ETH)
+        ForceEther forcer = new ForceEther();
+        vm.deal(address(forcer), 5 ether);
+        forcer.destroy(address(verseNFT));
+
+        // Contract now holds price + 5 ether, but mintRevenue is only price
+        assertEq(address(verseNFT).balance, price + 5 ether);
+        assertEq(verseNFT.mintRevenue(), price);
+
+        uint256 initialBalance = address(this).balance;
+        verseNFT.withdraw();
+        uint256 finalBalance = address(this).balance;
+
+        // Owner only receives mint revenue, not the force-sent ETH
+        assertEq(finalBalance - initialBalance, price);
+        // Stray ETH remains in contract
+        assertEq(address(verseNFT).balance, 5 ether);
+    }
+
+    function testWithdrawRevertsWhenNoRevenue() public {
+        vm.expectRevert(VerseNFT.NothingToWithdraw.selector);
+        verseNFT.withdraw();
+    }
+
+    function testMintRevenueTracksMultipleMints() public {
+        verseNFT.setMintCooldown(0);
+        vm.deal(user1, 100 ether);
+
+        uint256 price1 = verseNFT.mintPrice();
+        vm.prank(user1);
+        verseNFT.mint{value: price1}();
+
+        uint256 price2 = verseNFT.mintPrice();
+        vm.prank(user1);
+        verseNFT.mint{value: price2}();
+
+        assertEq(verseNFT.mintRevenue(), price1 + price2);
+
+        uint256 initialBalance = address(this).balance;
+        verseNFT.withdraw();
+        assertEq(address(this).balance - initialBalance, price1 + price2);
     }
 
     function testTokenURI() public {
@@ -400,4 +451,12 @@ contract VerseNFTTest is Test {
         verseNFT.mint{value: price}();
         assertEq(verseNFT.nextMintableTimestamp(user1), block.timestamp);
     }
+}
+
+/// @dev Helper to force-send ETH to a contract via selfdestruct
+contract ForceEther {
+    function destroy(address target) external {
+        selfdestruct(payable(target));
+    }
+    receive() external payable {}
 }


### PR DESCRIPTION
## Problem
`withdraw()` was calling `Address.sendValue(payable(msg.sender), address(this).balance)` which drains the **entire** contract balance. If any ETH from external sources accumulated in the contract, the owner could inadvertently sweep it.

## Fix
- Added `uint256 public mintRevenue` state variable
- Incremented on every successful public mint (`mintRevenue += msg.value`)
- `withdraw()` now only sends `mintRevenue`, resets to 0 after withdrawal
- Added `NothingToWithdraw` error for zero-balance guard

## Tests
- `testWithdrawOnlyMintRevenue` — verifies only mint proceeds are withdrawable, not stray ETH
- `testWithdrawRevertsWhenNoRevenue` — verifies revert when nothing to withdraw
- All 30 VerseNFT tests passing ✅

Closes #258