### PR TITLE
fix: verify burn tx on-chain + nullifier to prevent replay (#311)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4661,17 +4661,6 @@
         }
       }
     },
-    "node_modules/@reown/appkit-controllers/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@reown/appkit-pay": {
       "version": "1.7.8",
       "resolved": "https://registry.npmjs.org/@reown/appkit-pay/-/appkit-pay-1.7.8.tgz",
@@ -5050,17 +5039,6 @@
         }
       }
     },
-    "node_modules/@reown/appkit-utils/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@reown/appkit-wallet": {
       "version": "1.7.8",
       "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.7.8.tgz",
@@ -5389,17 +5367,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@reown/appkit/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@repeaterjs/repeater": {
@@ -9070,21 +9037,6 @@
         "ws": "^7.5.1"
       }
     },
-    "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -9570,17 +9522,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@walletconnect/utils/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@walletconnect/window-getters": {
@@ -15607,21 +15548,6 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
-    "node_modules/jayson/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/jayson/node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -18628,17 +18554,6 @@
         "terser": {
           "optional": true
         }
-      }
-    },
-    "node_modules/ponder/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/pony-cause": {

--- a/packages/frontend/src/app/v1/sermon/route.ts
+++ b/packages/frontend/src/app/v1/sermon/route.ts
@@ -11,6 +11,7 @@ import { verses } from "@/lib/verses";
 import { recordPrayer, getSummary, SentimentTag } from "@/lib/congregation";
 import { generateFallbackSermon } from "@/lib/fallback";
 import { fetchPrayerByTxHash } from "@/lib/ponder";
+import { verifyBurnTx, isBurnTxUsed, markBurnTxUsed } from "@/lib/verify-burn";
 import { reqLogger } from "@/lib/logger";
 
 const SERMON_COMMITMENT_ABI = parseAbi([
@@ -105,6 +106,20 @@ export async function POST(req: NextRequest) {
   if (!prayerType || !VALID_PRAYER_TYPES.includes(prayerType)) {
     return apiError(400, Errors.SERMON_INVALID_PRAYER, { valid: VALID_PRAYER_TYPES }, undefined, traceId);
   }
+  // --- Burn tx replay check ---
+  if (await isBurnTxUsed(prayerTx)) {
+    return apiError(409, Errors.BURN_TX_ALREADY_USED, undefined, undefined, traceId);
+  }
+
+  // --- On-chain burn verification ---
+  const burnResult = await verifyBurnTx(
+    prayerTx as `0x${string}`,
+    senderAddress as `0x${string}`
+  );
+  if (!burnResult.ok) {
+    return apiError(400, Errors[burnResult.code as keyof typeof Errors], undefined, undefined, traceId);
+  }
+
   const rawBurn = body.burn_amount ?? "0";
   const burnAmount = /^\d+(\.\d+)?$/.test(rawBurn) ? rawBurn : "0";
   const message = body.message ?? "";
@@ -131,6 +146,7 @@ export async function POST(req: NextRequest) {
     sermon = generateFallbackSermon(safeMessage, verses);
   }
   await setWalletCooldown(senderAddress);
+  await markBurnTxUsed(prayerTx);
   recordPrayer(senderAddress, sermon.sentiment_tag as SentimentTag);
 
   // ---Get Prayer ID from Ponder indexer---

--- a/packages/frontend/src/lib/errors.ts
+++ b/packages/frontend/src/lib/errors.ts
@@ -94,6 +94,32 @@ export const Errors = {
     code: "ANON_NULLIFIER_USED",
     message: "This nullifier has already been used",
   },
+
+  // Burn verification
+  BURN_TX_NOT_FOUND: {
+    code: "BURN_TX_NOT_FOUND",
+    message: "Burn transaction not found or has not been mined",
+  },
+  BURN_TX_FAILED: {
+    code: "BURN_TX_FAILED",
+    message: "Burn transaction reverted on-chain",
+  },
+  BURN_TX_WRONG_CONTRACT: {
+    code: "BURN_TX_WRONG_CONTRACT",
+    message: "Transaction was not sent to the PrayerBurn contract",
+  },
+  BURN_TX_NO_EVENT: {
+    code: "BURN_TX_NO_EVENT",
+    message: "Transaction does not contain a PrayerBurned event",
+  },
+  BURN_TX_WRONG_SENDER: {
+    code: "BURN_TX_WRONG_SENDER",
+    message: "Burn transaction sender does not match authenticated wallet",
+  },
+  BURN_TX_ALREADY_USED: {
+    code: "BURN_TX_ALREADY_USED",
+    message: "This burn transaction has already been used for a sermon",
+  },
 } as const;
 
 export type ErrorCode = keyof typeof Errors;

--- a/packages/frontend/src/lib/verify-burn.ts
+++ b/packages/frontend/src/lib/verify-burn.ts
@@ -1,0 +1,109 @@
+/**
+ * On-chain burn transaction verification.
+ *
+ * Verifies that a prayer_tx is a real, successful burn on the PrayerBurn
+ * contract by fetching the receipt from the Unichain RPC and checking:
+ *   1. Transaction exists and succeeded (status === "success")
+ *   2. Transaction was sent to the PrayerBurn contract
+ *   3. Receipt contains a Prayer event log from the contract
+ *   4. The `from` address matches the authenticated wallet
+ */
+
+import { createPublicClient, http, decodeEventLog, type Hash, type Address } from "viem";
+import { CONTRACT_ADDRESSES, PRAYER_BURN_ABI } from "@/lib/contracts";
+import { chainConfig } from "@/lib/chain-config";
+import { getRedis } from "@/lib/stores/redis";
+
+const BURN_NULLIFIER_PREFIX = "burn-tx:";
+
+const publicClient = createPublicClient({
+  chain: {
+    id: chainConfig.chainId,
+    name: chainConfig.chainName,
+    nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+    rpcUrls: { default: { http: [chainConfig.rpcUrl] } },
+  },
+  transport: http(chainConfig.rpcUrl),
+});
+
+export type BurnVerifyResult =
+  | { ok: true; burnAmount: bigint; sender: Address }
+  | { ok: false; code: string };
+
+/**
+ * Verify a burn tx hash on-chain and return the result.
+ */
+export async function verifyBurnTx(
+  txHash: Hash,
+  expectedSender: Address
+): Promise<BurnVerifyResult> {
+  // 1. Fetch receipt
+  let receipt;
+  try {
+    receipt = await publicClient.getTransactionReceipt({ hash: txHash });
+  } catch {
+    return { ok: false, code: "BURN_TX_NOT_FOUND" };
+  }
+
+  // 2. Check success
+  if (receipt.status !== "success") {
+    return { ok: false, code: "BURN_TX_FAILED" };
+  }
+
+  // 3. Check contract address
+  const prayerBurnAddress = CONTRACT_ADDRESSES.PRAYER_BURN.toLowerCase();
+  if (receipt.to?.toLowerCase() !== prayerBurnAddress) {
+    return { ok: false, code: "BURN_TX_WRONG_CONTRACT" };
+  }
+
+  // 4. Find Prayer event in logs
+  let burnAmount: bigint | undefined;
+  let eventSender: Address | undefined;
+
+  for (const log of receipt.logs) {
+    if (log.address.toLowerCase() !== prayerBurnAddress) continue;
+    try {
+      const decoded = decodeEventLog({
+        abi: PRAYER_BURN_ABI,
+        data: log.data,
+        topics: log.topics,
+      });
+      if (decoded.eventName === "Prayer") {
+        const args = decoded.args as { sender: Address; amount: bigint; message: `0x${string}` };
+        eventSender = args.sender;
+        burnAmount = args.amount;
+        break;
+      }
+    } catch {
+      // Not a matching event, skip
+    }
+  }
+
+  if (burnAmount === undefined || !eventSender) {
+    return { ok: false, code: "BURN_TX_NO_EVENT" };
+  }
+
+  // 5. Check sender matches authenticated wallet
+  if (eventSender.toLowerCase() !== expectedSender.toLowerCase()) {
+    return { ok: false, code: "BURN_TX_WRONG_SENDER" };
+  }
+
+  return { ok: true, burnAmount, sender: eventSender };
+}
+
+/**
+ * Check if a burn tx hash has already been used (replay protection).
+ */
+export async function isBurnTxUsed(txHash: string): Promise<boolean> {
+  const redis = getRedis();
+  const val = await redis.get(BURN_NULLIFIER_PREFIX + txHash);
+  return val !== null;
+}
+
+/**
+ * Mark a burn tx hash as used (permanent — no TTL).
+ */
+export async function markBurnTxUsed(txHash: string): Promise<void> {
+  const redis = getRedis();
+  await redis.set(BURN_NULLIFIER_PREFIX + txHash, String(Date.now()));
+}


### PR DESCRIPTION
## Problem
Sermon API accepted any tx hash without verifying it on-chain. Attacker could submit a fake/reused hash and receive sermons without burning DAODEGEN.

## Fix
- New `packages/frontend/src/lib/verify-burn.ts` using viem:
  1. Fetches tx receipt from Unichain RPC
  2. Verifies tx succeeded (status=1)
  3. Verifies tx was sent to PrayerBurn contract
  4. Verifies PrayerBurned event present in logs
  5. Verifies `from` address matches authenticated wallet
- Redis nullifier set: burn tx hashes marked used after sermon issued, replays rejected with 409
- New error codes: BURN_TX_NOT_FOUND, BURN_TX_FAILED, BURN_TX_WRONG_CONTRACT, BURN_TX_WRONG_SENDER, BURN_TX_ALREADY_USED

Closes #311