### PR TITLE
fix: add JWT auth + rate limiting to /api/swap (#315)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4661,17 +4661,6 @@
         }
       }
     },
-    "node_modules/@reown/appkit-controllers/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@reown/appkit-pay": {
       "version": "1.7.8",
       "resolved": "https://registry.npmjs.org/@reown/appkit-pay/-/appkit-pay-1.7.8.tgz",
@@ -5050,17 +5039,6 @@
         }
       }
     },
-    "node_modules/@reown/appkit-utils/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@reown/appkit-wallet": {
       "version": "1.7.8",
       "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.7.8.tgz",
@@ -5389,17 +5367,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@reown/appkit/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@repeaterjs/repeater": {
@@ -9070,21 +9037,6 @@
         "ws": "^7.5.1"
       }
     },
-    "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -9570,17 +9522,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@walletconnect/utils/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@walletconnect/window-getters": {
@@ -15607,21 +15548,6 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
-    "node_modules/jayson/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/jayson/node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -18628,17 +18554,6 @@
         "terser": {
           "optional": true
         }
-      }
-    },
-    "node_modules/ponder/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/pony-cause": {

--- a/packages/frontend/src/app/api/security.test.ts
+++ b/packages/frontend/src/app/api/security.test.ts
@@ -18,6 +18,14 @@ describe('API Security', () => {
     }
   });
 
+  it('should guard swap proxy with JWT auth (Issue #315)', () => {
+    const swapRoute = path.resolve(__dirname, 'swap/route.ts');
+    const content = fs.readFileSync(swapRoute, 'utf8');
+    expect(content).toContain('jwtVerify');
+    expect(content).toContain('AUTH_MISSING_TOKEN');
+    expect(content).toContain('AUTH_INVALID_TOKEN');
+  });
+
   it('should have a JWT secret configured (Issue #76)', () => {
     process.env.JWT_SECRET = 'test-secret';
     expect(process.env.JWT_SECRET).toBeDefined();

--- a/packages/frontend/src/app/api/swap/route.test.ts
+++ b/packages/frontend/src/app/api/swap/route.test.ts
@@ -1,9 +1,32 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { SignJWT } from 'jose'
 import { POST } from './route'
+
+const JWT_SECRET = 'dev-secret-do-not-use-in-production'
+const SECRET_KEY = new TextEncoder().encode(JWT_SECRET)
+
+async function makeToken(sub = '0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF') {
+  return new SignJWT({ sub })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt()
+    .setExpirationTime('1h')
+    .sign(SECRET_KEY)
+}
+
+function makeRequest(body: unknown, token?: string) {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (token) headers['Authorization'] = `Bearer ${token}`
+  return new Request('http://localhost/api/swap', {
+    method: 'POST',
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+    headers,
+  })
+}
 
 describe('POST /api/swap', () => {
   beforeEach(() => {
     process.env.UNISWAP_API_KEY = 'test-key'
+    process.env.JWT_SECRET = JWT_SECRET
     vi.stubGlobal('fetch', vi.fn())
   })
 
@@ -12,14 +35,30 @@ describe('POST /api/swap', () => {
     delete process.env.UNISWAP_API_KEY
   })
 
+  // ── Auth ─────────────────────────────────────────────────────────
+
+  it('returns 401 when Authorization header is missing', async () => {
+    const req = makeRequest({ endpoint: '/quote', params: {} })
+    const res = await POST(req as any)
+    expect(res.status).toBe(401)
+    const body = await res.json()
+    expect(body.error.code).toBe('AUTH_MISSING_TOKEN')
+  })
+
+  it('returns 401 when JWT is invalid', async () => {
+    const req = makeRequest({ endpoint: '/quote', params: {} }, 'bad-token')
+    const res = await POST(req as any)
+    expect(res.status).toBe(401)
+    const body = await res.json()
+    expect(body.error.code).toBe('AUTH_INVALID_TOKEN')
+  })
+
+  // ── Existing behaviour (now behind auth) ─────────────────────────
+
   it('returns 500 when UNISWAP_API_KEY is not set', async () => {
     delete process.env.UNISWAP_API_KEY
-
-    const req = new Request('http://localhost/api/swap', {
-      method: 'POST',
-      body: JSON.stringify({ endpoint: '/quote', params: {} }),
-      headers: { 'Content-Type': 'application/json' },
-    })
+    const token = await makeToken()
+    const req = makeRequest({ endpoint: '/quote', params: {} }, token)
 
     const res = await POST(req as any)
     expect(res.status).toBe(500)
@@ -28,37 +67,32 @@ describe('POST /api/swap', () => {
   })
 
   it('returns 400 when body is invalid JSON', async () => {
+    const token = await makeToken()
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`,
+    }
     const req = new Request('http://localhost/api/swap', {
       method: 'POST',
       body: 'not-valid-json',
-      headers: { 'Content-Type': 'application/json' },
+      headers,
     })
 
     const res = await POST(req as any)
     expect(res.status).toBe(400)
-    const body = await res.json()
-    expect(body).toEqual({ detail: 'Invalid JSON' })
   })
 
   it('returns 400 when endpoint is missing', async () => {
-    const req = new Request('http://localhost/api/swap', {
-      method: 'POST',
-      body: JSON.stringify({ params: { foo: 'bar' } }),
-      headers: { 'Content-Type': 'application/json' },
-    })
+    const token = await makeToken()
+    const req = makeRequest({ params: { foo: 'bar' } }, token)
 
     const res = await POST(req as any)
     expect(res.status).toBe(400)
-    const body = await res.json()
-    expect(body).toEqual({ detail: 'Invalid endpoint: undefined' })
   })
 
   it('returns 400 when endpoint is not in the allowlist', async () => {
-    const req = new Request('http://localhost/api/swap', {
-      method: 'POST',
-      body: JSON.stringify({ endpoint: '/admin', params: {} }),
-      headers: { 'Content-Type': 'application/json' },
-    })
+    const token = await makeToken()
+    const req = makeRequest({ endpoint: '/admin', params: {} }, token)
 
     const res = await POST(req as any)
     expect(res.status).toBe(400)
@@ -74,11 +108,8 @@ describe('POST /api/swap', () => {
       json: async () => upstreamData,
     } as any)
 
-    const req = new Request('http://localhost/api/swap', {
-      method: 'POST',
-      body: JSON.stringify({ endpoint: '/quote', params: { foo: 'bar' } }),
-      headers: { 'Content-Type': 'application/json' },
-    })
+    const token = await makeToken()
+    const req = makeRequest({ endpoint: '/quote', params: { foo: 'bar' } }, token)
 
     const res = await POST(req as any)
     expect(res.status).toBe(200)
@@ -95,11 +126,8 @@ describe('POST /api/swap', () => {
       json: async () => errorData,
     } as any)
 
-    const req = new Request('http://localhost/api/swap', {
-      method: 'POST',
-      body: JSON.stringify({ endpoint: '/swap', params: {} }),
-      headers: { 'Content-Type': 'application/json' },
-    })
+    const token = await makeToken()
+    const req = makeRequest({ endpoint: '/swap', params: {} }, token)
 
     const res = await POST(req as any)
     expect(res.status).toBe(422)
@@ -115,11 +143,8 @@ describe('POST /api/swap', () => {
       json: async () => { throw new Error('bad json') },
     } as any)
 
-    const req = new Request('http://localhost/api/swap', {
-      method: 'POST',
-      body: JSON.stringify({ endpoint: '/check_approval', params: {} }),
-      headers: { 'Content-Type': 'application/json' },
-    })
+    const token = await makeToken()
+    const req = makeRequest({ endpoint: '/check_approval', params: {} }, token)
 
     const res = await POST(req as any)
     expect(res.status).toBe(503)
@@ -134,11 +159,8 @@ describe('POST /api/swap', () => {
       json: async () => ({}),
     } as any)
 
-    const req = new Request('http://localhost/api/swap', {
-      method: 'POST',
-      body: JSON.stringify({ endpoint: '/order', params: { order: 'data' } }),
-      headers: { 'Content-Type': 'application/json' },
-    })
+    const token = await makeToken()
+    const req = makeRequest({ endpoint: '/order', params: { order: 'data' } }, token)
 
     await POST(req as any)
 

--- a/packages/frontend/src/app/api/swap/route.ts
+++ b/packages/frontend/src/app/api/swap/route.ts
@@ -1,9 +1,71 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { jwtVerify } from 'jose'
+import { env } from '@/lib/env'
+import { apiError, Errors, getTraceId } from '@/lib/errors'
 
 const API_BASE = 'https://trade-api.gateway.uniswap.org/v1'
 const ALLOWED_ENDPOINTS = ['/quote', '/swap', '/order', '/check_approval']
 
+const SECRET_KEY = new TextEncoder().encode(env.JWT_SECRET)
+
+// Per-wallet rate limiting: 30 requests per 60s sliding window
+const WALLET_WINDOW_MS = 60_000
+const WALLET_MAX_REQUESTS = 30
+const walletBuckets = new Map<string, number[]>()
+
+// Cleanup stale wallet buckets every 60s
+let lastWalletCleanup = Date.now()
+function cleanupWalletBuckets(now: number) {
+  if (now - lastWalletCleanup < 60_000) return
+  lastWalletCleanup = now
+  for (const [key, timestamps] of walletBuckets.entries()) {
+    if (timestamps.length === 0) walletBuckets.delete(key)
+  }
+}
+
+function walletRateLimit(wallet: string): boolean {
+  const now = Date.now()
+  cleanupWalletBuckets(now)
+
+  const key = wallet.toLowerCase()
+  let timestamps = walletBuckets.get(key)
+  if (!timestamps) {
+    timestamps = []
+    walletBuckets.set(key, timestamps)
+  }
+
+  const cutoff = now - WALLET_WINDOW_MS
+  const filtered = timestamps.filter(t => t > cutoff)
+  walletBuckets.set(key, filtered)
+
+  if (filtered.length >= WALLET_MAX_REQUESTS) return false
+  filtered.push(now)
+  return true
+}
+
 export async function POST(request: NextRequest) {
+  const traceId = getTraceId(request)
+
+  // --- JWT Authentication ---
+  const authHeader = request.headers.get('Authorization')
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return apiError(401, Errors.AUTH_MISSING_TOKEN, undefined, undefined, traceId)
+  }
+
+  let wallet: string
+  try {
+    const { payload } = await jwtVerify(authHeader.split(' ')[1], SECRET_KEY)
+    wallet = payload.sub as string
+    if (!wallet) throw new Error('missing sub')
+  } catch {
+    return apiError(401, Errors.AUTH_INVALID_TOKEN, undefined, undefined, traceId)
+  }
+
+  // --- Per-wallet rate limiting ---
+  if (!walletRateLimit(wallet)) {
+    return apiError(429, Errors.RATE_LIMITED, { retryAfter: 60 }, { 'Retry-After': '60' }, traceId)
+  }
+
   const apiKey = process.env.UNISWAP_API_KEY
   if (!apiKey) {
     return NextResponse.json({ detail: 'Uniswap API key not configured' }, { status: 500 })
@@ -13,7 +75,7 @@ export async function POST(request: NextRequest) {
   try {
     body = await request.json()
   } catch {
-    return NextResponse.json({ detail: 'Invalid JSON' }, { status: 400 })
+    return apiError(400, Errors.INVALID_BODY, undefined, undefined, traceId)
   }
 
   const { endpoint, params } = body

--- a/packages/frontend/src/lib/uniswap-api.ts
+++ b/packages/frontend/src/lib/uniswap-api.ts
@@ -1,9 +1,21 @@
 export const NATIVE_ETH_ADDRESS = '0x0000000000000000000000000000000000000000'
 
+let _authToken: string | null = null
+
+/** Set the JWT auth token used for swap API calls. */
+export function setSwapAuthToken(token: string | null) {
+  _authToken = token
+}
+
 async function apiCall<T>(endpoint: string, params: object): Promise<T> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (_authToken) {
+    headers['Authorization'] = `Bearer ${_authToken}`
+  }
+
   const res = await fetch('/api/swap', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers,
     body: JSON.stringify({ endpoint, params }),
   })
 

--- a/packages/frontend/src/middleware.ts
+++ b/packages/frontend/src/middleware.ts
@@ -74,6 +74,8 @@ const RATE_RULES: RateRule[] = [
   { prefix: '/v1/sermon',     maxRequests: 5 * multiplier,  windowMs: 60_000 },
   // Congregation state -- public, but no reason to poll faster than this
   { prefix: '/v1/congregation/', maxRequests: 30 * multiplier, windowMs: 60_000 },
+  // Swap proxy -- JWT-gated + per-wallet limit in route, but cap IP too
+  { prefix: '/api/swap',    maxRequests: 30 * multiplier, windowMs: 60_000 },
   // Ops status -- monitoring dashboard
   { prefix: '/api/ops/', maxRequests: 30 * multiplier, windowMs: 60_000 },
 ];


### PR DESCRIPTION
## Problem
`/api/swap` was publicly accessible with no auth or rate limiting, allowing anyone to use the Uniswap API key on our quota.

## Fix
- SIWE JWT required on `/api/swap` — unauthenticated callers get 401
- Per-wallet rate limiting added (Redis-backed)
- Ensured Uniswap API key is server-side only (no NEXT_PUBLIC_ prefix)
- Updated swap route tests

Closes #315