### PR TITLE
fix: refund excess ETH on mint — bonding curve race condition (#293)

### DIFF
--- a/packages/contracts/src/VerseNFT.sol
+++ b/packages/contracts/src/VerseNFT.sol
@@ -34,6 +34,7 @@ contract VerseNFT is ERC721Enumerable, Ownable, Pausable {
     event BaseMintPriceUpdated(uint256 newPrice);
     event PriceIncrementUpdated(uint256 newIncrement);
     event MintCooldownUpdated(uint256 newCooldown);
+    event MintRefunded(address indexed minter, uint256 excess);
 
     constructor(
         string memory _initialBaseURI,
@@ -57,7 +58,8 @@ contract VerseNFT is ERC721Enumerable, Ownable, Pausable {
         if (mintCooldown > 0 && lastMintTimestamp[msg.sender] > 0 && block.timestamp < lastMintTimestamp[msg.sender] + mintCooldown) {
             revert MintCooldownActive();
         }
-        if (msg.value < mintPrice()) revert InsufficientPayment();
+        uint256 price = mintPrice();
+        if (msg.value < price) revert InsufficientPayment();
 
         while (_nextTokenId <= MAX_SUPPLY && _ownerOf(_nextTokenId) != address(0)) {
             _nextTokenId++;
@@ -66,9 +68,15 @@ contract VerseNFT is ERC721Enumerable, Ownable, Pausable {
         if (_nextTokenId > MAX_SUPPLY) revert MaxSupplyReached();
 
         lastMintTimestamp[msg.sender] = block.timestamp;
-        mintRevenue += msg.value;
+        mintRevenue += price;
         _safeMint(msg.sender, _nextTokenId);
         _nextTokenId++;
+
+        uint256 excess = msg.value - price;
+        if (excess > 0) {
+            emit MintRefunded(msg.sender, excess);
+            Address.sendValue(payable(msg.sender), excess);
+        }
     }
 
     /// @notice Owner can mint specific verse IDs

--- a/packages/contracts/test/VerseNFT.t.sol
+++ b/packages/contracts/test/VerseNFT.t.sol
@@ -440,6 +440,42 @@ contract VerseNFTTest is Test {
         assertEq(verseNFT.nextMintableTimestamp(user1), block.timestamp);
     }
 
+    // ---- Mint Refund Tests ----
+
+    function testMintRefundsExcess() public {
+        vm.deal(user1, 10 ether);
+        uint256 price = verseNFT.mintPrice();
+        uint256 overpay = price * 2;
+
+        uint256 balanceBefore = user1.balance;
+
+        vm.prank(user1);
+        vm.expectEmit(true, false, false, true, address(verseNFT));
+        emit VerseNFT.MintRefunded(user1, overpay - price);
+        verseNFT.mint{value: overpay}();
+
+        // User paid only the exact price (refund returned the excess)
+        assertEq(balanceBefore - user1.balance, price);
+        // mintRevenue tracks only the price, not the overpayment
+        assertEq(verseNFT.mintRevenue(), price);
+    }
+
+    function testMintExactPaymentNoRefund() public {
+        vm.deal(user1, 10 ether);
+        uint256 price = verseNFT.mintPrice();
+
+        uint256 balanceBefore = user1.balance;
+
+        vm.prank(user1);
+        verseNFT.mint{value: price}();
+
+        // User paid exactly the price — no refund
+        assertEq(balanceBefore - user1.balance, price);
+        assertEq(verseNFT.mintRevenue(), price);
+        // Contract holds exactly the price
+        assertEq(address(verseNFT).balance, price);
+    }
+
     function testNextMintableTimestampWithZeroCooldown() public {
         verseNFT.setMintCooldown(0);
         assertEq(verseNFT.nextMintableTimestamp(user1), block.timestamp);


### PR DESCRIPTION
## Problem
`mint()` captured all of `msg.value` into `mintRevenue` even when user overpaid. On a bonding curve, price changes between blocks — a user estimating price could overshoot if another mint lands first, permanently losing the excess to the owner.

## Fix
- Captures exact `price = mintPrice()` at mint time
- `mintRevenue += price` (not `msg.value`)
- Excess (`msg.value - price`) refunded immediately via `Address.sendValue()`
- Added `MintRefunded(address indexed minter, uint256 excess)` event

## Tests (32 passing ✅)
- `testMintRefundsExcess` — user overpays 2x, gets refund, mintRevenue only tracks exact price
- `testMintExactPaymentNoRefund` — exact payment, no refund emitted

Closes #293