### PR TITLE
fix: add rescueETH() to recover accidentally sent ETH from DaoDeGenHook (#307)

### DIFF
--- a/packages/contracts/src/DaoDeGenHook.sol
+++ b/packages/contracts/src/DaoDeGenHook.sol
@@ -53,6 +53,7 @@ contract DaoDeGenHook is IHooks, IUnlockCallback {
     event PauseScheduled(bool paused, uint256 executeAfter);
     event HookPauseChanged(bool paused);
     event FeesAccrued(Currency indexed currency, uint256 amount);
+    event ETHRescued(address indexed to, uint256 amount);
 
     modifier whenNotPaused() {
         if (paused) revert HookPaused();
@@ -209,6 +210,17 @@ contract DaoDeGenHook is IHooks, IUnlockCallback {
     function unlockCallback(bytes calldata) external override returns (bytes memory) {
         if (msg.sender != address(manager)) revert OnlyPoolManager();
         return "";
+    }
+
+    /// @notice Recover ETH accidentally sent to this contract.
+    /// @param to Address to send the ETH to.
+    function rescueETH(address to) external {
+        if (msg.sender != owner) revert NotOwner();
+        if (to == address(0)) revert InvalidAddress();
+        uint256 balance = address(this).balance;
+        (bool ok,) = to.call{value: balance}("");
+        require(ok, "ETH transfer failed");
+        emit ETHRescued(to, balance);
     }
 
     receive() external payable {}

--- a/packages/contracts/test/DaoDeGenHook.t.sol
+++ b/packages/contracts/test/DaoDeGenHook.t.sol
@@ -339,6 +339,50 @@ contract DaoDeGenHookTest is Test {
         assertEq(address(jar).balance, expectedFee);
     }
 
+    // -------------------------------------------------------------------------
+    // rescueETH tests (Issue #307)
+    // -------------------------------------------------------------------------
+
+    function test_RescueETH_OwnerCanRecover() public {
+        vm.deal(address(hook), 5 ether);
+        address recipient = makeAddr("recipient");
+
+        vm.expectEmit(true, true, true, true);
+        emit DaoDeGenHook.ETHRescued(recipient, 5 ether);
+        hook.rescueETH(recipient);
+
+        assertEq(address(hook).balance, 0);
+        assertEq(recipient.balance, 5 ether);
+    }
+
+    function test_RescueETH_RevertsForNonOwner() public {
+        vm.deal(address(hook), 1 ether);
+        address nonOwner = makeAddr("nonOwner");
+
+        vm.prank(nonOwner);
+        vm.expectRevert(DaoDeGenHook.NotOwner.selector);
+        hook.rescueETH(makeAddr("recipient"));
+    }
+
+    function test_RescueETH_RevertsForZeroAddress() public {
+        vm.deal(address(hook), 1 ether);
+        vm.expectRevert(DaoDeGenHook.InvalidAddress.selector);
+        hook.rescueETH(address(0));
+    }
+
+    function test_RescueETH_ZeroBalance() public {
+        address recipient = makeAddr("recipient");
+        hook.rescueETH(recipient);
+        assertEq(recipient.balance, 0);
+    }
+
+    function test_Receive_AcceptsETH() public {
+        vm.deal(address(this), 1 ether);
+        (bool ok,) = address(hook).call{value: 1 ether}("");
+        assertTrue(ok);
+        assertEq(address(hook).balance, 1 ether);
+    }
+
     function test_AfterSwap_RevertsForNonManager() public {
         PoolKey memory key = PoolKey({
             currency0: Currency.wrap(address(0)),


### PR DESCRIPTION
## Problem
`DaoDeGenHook` has a `receive()` function accepting arbitrary ETH with no recovery mechanism — any ETH sent directly to the contract is permanently locked.

## Fix
- Added `rescueETH(address to) onlyOwner` — sends full contract ETH balance to specified address
- Added `ETHRescued(address indexed to, uint256 amount)` event
- 22 tests passing ✅

Closes #307