### PR TITLE
fix: add nonReentrant modifier to VerseNFT.mint() (#306)

### DIFF
--- a/packages/contracts/src/VerseNFT.sol
+++ b/packages/contracts/src/VerseNFT.sol
@@ -5,12 +5,13 @@ import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import {ERC721Enumerable} from "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 
 /// @title VerseNFT
 /// @notice 81 NFTs — one per verse of the Dao DeGen
-contract VerseNFT is ERC721Enumerable, Ownable, Pausable {
+contract VerseNFT is ERC721Enumerable, Ownable, Pausable, ReentrancyGuard {
     using Strings for uint256;
 
     uint256 public constant MAX_SUPPLY = 81;
@@ -53,7 +54,7 @@ contract VerseNFT is ERC721Enumerable, Ownable, Pausable {
     }
 
     /// @notice Mint the next available verse NFT
-    function mint() external payable whenNotPaused {
+    function mint() external payable whenNotPaused nonReentrant {
         if (mintCooldown > 0 && lastMintTimestamp[msg.sender] > 0 && block.timestamp < lastMintTimestamp[msg.sender] + mintCooldown) {
             revert MintCooldownActive();
         }

--- a/packages/contracts/test/VerseNFT.t.sol
+++ b/packages/contracts/test/VerseNFT.t.sol
@@ -451,6 +451,42 @@ contract VerseNFTTest is Test {
         verseNFT.mint{value: price}();
         assertEq(verseNFT.nextMintableTimestamp(user1), block.timestamp);
     }
+
+    // ---- Reentrancy Guard Test ----
+
+    function testMintReentrancyReverts() public {
+        verseNFT.setMintCooldown(0);
+
+        ReentrantMinter attacker = new ReentrantMinter(verseNFT);
+        vm.deal(address(attacker), 100 ether);
+
+        vm.expectRevert();
+        attacker.attack();
+    }
+}
+
+/// @dev Malicious contract that attempts reentrancy via onERC721Received
+contract ReentrantMinter {
+    VerseNFT private target;
+
+    constructor(VerseNFT _target) {
+        target = _target;
+    }
+
+    function attack() external {
+        uint256 price = target.mintPrice();
+        target.mint{value: price}();
+    }
+
+    function onERC721Received(address, address, uint256, bytes calldata) external returns (bytes4) {
+        uint256 price = target.mintPrice();
+        if (address(this).balance >= price) {
+            target.mint{value: price}();
+        }
+        return this.onERC721Received.selector;
+    }
+
+    receive() external payable {}
 }
 
 /// @dev Helper to force-send ETH to a contract via selfdestruct


### PR DESCRIPTION
## Problem
`VerseNFT.mint()` had no reentrancy protection. The ETH refund (added in #293) creates a callback opportunity before state is finalized.

## Fix
- Inherited OpenZeppelin `ReentrancyGuard`
- Added `nonReentrant` modifier to `mint()`
- 31 tests passing ✅

Closes #306