### PR TITLE
fix: add onlyOwner to PrayerBurn.approveJar() (#310)

### DIFF
--- a/packages/contracts/src/PrayerBurn.sol
+++ b/packages/contracts/src/PrayerBurn.sol
@@ -142,7 +142,7 @@ contract PrayerBurn is Ownable, ReentrancyGuard {
 
     /// @notice Approve the Jar to spend this contract's DAODEGEN for release burns.
     ///         Call after funding this contract with DAODEGEN tokens.
-    function approveJar() external {
+    function approveJar() external onlyOwner {
         daodegen.approve(address(jar), type(uint256).max);
     }
 

--- a/packages/contracts/test/PrayerBurn.t.sol
+++ b/packages/contracts/test/PrayerBurn.t.sol
@@ -450,10 +450,14 @@ contract PrayerBurnTest is Test {
         vm.stopPrank();
     }
 
-    function testApproveJarAnyone() public {
-        // Anyone can call approveJar -- it just approves the jar to spend
-        // PrayerBurn's tokens, which is harmless
+    function testApproveJar() public {
+        prayer.approveJar();
+        assertEq(token.allowance(address(prayer), address(jar)), type(uint256).max);
+    }
+
+    function testApproveJarOnlyOwner() public {
         vm.prank(user1);
+        vm.expectRevert();
         prayer.approveJar();
     }
 }


### PR DESCRIPTION
## Problem
`approveJar()` was callable by anyone, allowing any address to approve the jar contract for token transfers on behalf of PrayerBurn.

## Fix
- Added `onlyOwner` modifier to `approveJar()`
- 34 tests passing ✅

Closes #310