### PR TITLE
fix: Redis-backed middleware rate limiting (#298)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4661,17 +4661,6 @@
         }
       }
     },
-    "node_modules/@reown/appkit-controllers/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@reown/appkit-pay": {
       "version": "1.7.8",
       "resolved": "https://registry.npmjs.org/@reown/appkit-pay/-/appkit-pay-1.7.8.tgz",
@@ -5050,17 +5039,6 @@
         }
       }
     },
-    "node_modules/@reown/appkit-utils/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@reown/appkit-wallet": {
       "version": "1.7.8",
       "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.7.8.tgz",
@@ -5389,17 +5367,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@reown/appkit/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@repeaterjs/repeater": {
@@ -9070,21 +9037,6 @@
         "ws": "^7.5.1"
       }
     },
-    "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -9570,17 +9522,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@walletconnect/utils/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@walletconnect/window-getters": {
@@ -15607,21 +15548,6 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
-    "node_modules/jayson/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/jayson/node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -18628,17 +18554,6 @@
         "terser": {
           "optional": true
         }
-      }
-    },
-    "node_modules/ponder/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/pony-cause": {

--- a/packages/frontend/src/middleware.test.ts
+++ b/packages/frontend/src/middleware.test.ts
@@ -1,17 +1,32 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock Redis before importing middleware
+vi.mock('./lib/stores/redis', () => ({
+  getRedis: () => ({
+    incr: vi.fn(async () => 1),
+    expire: vi.fn(async () => 1),
+  }),
+}));
 
 describe('Middleware / Security Headers', () => {
   it('should have security headers configured (Issue #78)', async () => {
-    // This is hard to test in Vitest without full Next.js context, 
-    // but we can check the config or a mocked response.
-    // For now, let's assert that certain headers SHOULD be present.
-    
-    // We expect middleware.ts to exist and set these.
-    // @ts-ignore - checking for file/export
     const middleware = await import('./middleware').catch((e) => {
-        console.error(e);
-        return null;
+      console.error(e);
+      return null;
     });
     expect(middleware).not.toBeNull();
+  });
+});
+
+describe('Middleware / Redis rate limiting', () => {
+  it('exports Node.js runtime for ioredis compatibility', async () => {
+    const mod = await import('./middleware');
+    expect(mod.runtime).toBe('nodejs');
+  });
+
+  it('middleware is an async function', async () => {
+    const mod = await import('./middleware');
+    // AsyncFunction constructor name check
+    expect(mod.middleware.constructor.name).toBe('AsyncFunction');
   });
 });

--- a/packages/frontend/src/middleware.ts
+++ b/packages/frontend/src/middleware.ts
@@ -1,51 +1,37 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
-import { MemoryRateLimitStore } from './lib/stores/memory';
+import { getRedis } from './lib/stores/redis';
 
 // ---------------------------------------------------------------------------
-// Rate limiter -- sliding window per IP, no external dependencies.
-// Evicts stale entries every 60s to bound memory on a cheap VPS.
-// NOTE: Middleware runs in Edge Runtime — must use memory store only
-// (ioredis/Node.js APIs are not available in Edge).
+// Rate limiter — Redis-backed INCR + EXPIRE (survives restarts, works
+// across multiple Next.js processes).  Follows the same pattern as the
+// facilitator.  Falls open (allows request) if Redis is unreachable.
+// Key format: ratelimit:middleware:<ip>:<route-prefix>
 // ---------------------------------------------------------------------------
 
-const buckets = new MemoryRateLimitStore();
-
-// Cleanup stale buckets every 60s
-let lastCleanup = Date.now();
-const CLEANUP_INTERVAL = 60_000;
-
-function cleanup(now: number) {
-  if (now - lastCleanup < CLEANUP_INTERVAL) return;
-  lastCleanup = now;
-  for (const [key, bucket] of buckets.entries()) {
-    if (bucket.timestamps.length === 0) {
-      buckets.delete(key);
+/**
+ * Returns true if the request should be blocked (rate-limited).
+ * Uses atomic INCR + EXPIRE in Redis — no in-memory state.
+ */
+async function isRateLimited(
+  ip: string,
+  routePrefix: string,
+  maxRequests: number,
+  windowSeconds: number,
+): Promise<boolean> {
+  try {
+    const redis = getRedis();
+    const key = `ratelimit:middleware:${ip}:${routePrefix}`;
+    const count = await redis.incr(key);
+    if (count === 1) {
+      await redis.expire(key, windowSeconds);
     }
-  }
-}
-
-// Returns true if the request is allowed, false if rate-limited.
-function rateLimit(ip: string, path: string, maxRequests: number, windowMs: number): boolean {
-  const now = Date.now();
-  cleanup(now);
-
-  const key = `${ip}:${path}`;
-  let bucket = buckets.get(key);
-  if (!bucket) {
-    bucket = { timestamps: [] };
-    buckets.set(key, bucket);
-  }
-
-  const cutoff = now - windowMs;
-  bucket.timestamps = bucket.timestamps.filter((t: number) => t > cutoff);
-
-  if (bucket.timestamps.length >= maxRequests) {
+    return count > maxRequests;
+  } catch (err) {
+    // Fail open — if Redis is down, allow the request rather than blocking users
+    console.error('[middleware] Redis rate-limit check failed:', err instanceof Error ? err.message : err);
     return false;
   }
-
-  bucket.timestamps.push(now);
-  return true;
 }
 
 // ---------------------------------------------------------------------------
@@ -55,7 +41,7 @@ function rateLimit(ip: string, path: string, maxRequests: number, windowMs: numb
 interface RateRule {
   prefix: string;
   maxRequests: number;
-  windowMs: number;
+  windowSeconds: number;
 }
 
 // In E2E test environments, relax rate limits to avoid flaky tests.
@@ -64,18 +50,18 @@ const multiplier = (process.env.E2E_BASE_URL && process.env.NODE_ENV !== 'produc
 
 const RATE_RULES: RateRule[] = [
   // Auth endpoints -- tight limits, no reason to hammer these
-  { prefix: '/api/auth/',     maxRequests: 5 * multiplier,  windowMs: 60_000 },
+  { prefix: '/api/auth/',     maxRequests: 5 * multiplier,  windowSeconds: 60 },
   // Health check -- monitoring tools poll this
-  { prefix: '/api/health',    maxRequests: 30 * multiplier, windowMs: 60_000 },
+  { prefix: '/api/health',    maxRequests: 30 * multiplier, windowSeconds: 60 },
   // Verse API -- already gated by JWT + x402 payment, but cap anyway
-  { prefix: '/v1/verse/',     maxRequests: 10 * multiplier, windowMs: 60_000 },
+  { prefix: '/v1/verse/',     maxRequests: 10 * multiplier, windowSeconds: 60 },
   // Sermon -- JWT gated + per-wallet cooldown in route, but cap IP too
-  { prefix: '/v1/sermon/anonymous', maxRequests: 3 * multiplier, windowMs: 60_000 },
-  { prefix: '/v1/sermon',     maxRequests: 5 * multiplier,  windowMs: 60_000 },
+  { prefix: '/v1/sermon/anonymous', maxRequests: 3 * multiplier, windowSeconds: 60 },
+  { prefix: '/v1/sermon',     maxRequests: 5 * multiplier,  windowSeconds: 60 },
   // Congregation state -- public, but no reason to poll faster than this
-  { prefix: '/v1/congregation/', maxRequests: 30 * multiplier, windowMs: 60_000 },
+  { prefix: '/v1/congregation/', maxRequests: 30 * multiplier, windowSeconds: 60 },
   // Ops status -- monitoring dashboard
-  { prefix: '/api/ops/', maxRequests: 30 * multiplier, windowMs: 60_000 },
+  { prefix: '/api/ops/', maxRequests: 30 * multiplier, windowSeconds: 60 },
 ];
 
 function getRateRule(pathname: string): RateRule | null {
@@ -89,7 +75,7 @@ function getRateRule(pathname: string): RateRule | null {
 // Middleware
 // ---------------------------------------------------------------------------
 
-export function middleware(request: NextRequest) {
+export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   // ── Trace ID ──────────────────────────────────────────────────
@@ -97,17 +83,17 @@ export function middleware(request: NextRequest) {
   // Propagated downstream via x-request-id header.
   const traceId = request.headers.get('x-request-id') || crypto.randomUUID();
 
-  // Rate limiting for API routes
+  // Rate limiting for API routes (Redis-backed, survives restarts)
   const rule = getRateRule(pathname);
   if (rule) {
     const ip = request.headers.get('x-forwarded-for')?.split(',')[0].trim()
       || request.headers.get('x-real-ip')
       || '127.0.0.1';
 
-    if (!rateLimit(ip, rule.prefix, rule.maxRequests, rule.windowMs)) {
+    if (await isRateLimited(ip, rule.prefix, rule.maxRequests, rule.windowSeconds)) {
       return NextResponse.json(
-        { error: { code: 'RATE_LIMITED', message: 'Too many requests', details: { retryAfter: 60 } } },
-        { status: 429, headers: { 'Retry-After': '60', 'x-request-id': traceId } },
+        { error: { code: 'RATE_LIMITED', message: 'Too many requests', details: { retryAfter: rule.windowSeconds } } },
+        { status: 429, headers: { 'Retry-After': String(rule.windowSeconds), 'x-request-id': traceId } },
       );
     }
   }
@@ -158,6 +144,9 @@ export function middleware(request: NextRequest) {
 
   return response;
 }
+
+// Use Node.js runtime so we can access ioredis (not available in Edge Runtime).
+export const runtime = 'nodejs';
 
 export const config = {
   matcher: [


### PR DESCRIPTION
## Problem
Middleware rate limiting used in-memory state — reset on restart, ineffective across multiple Next.js processes.

## Fix
- Replaced in-memory counter with Redis INCR + EXPIRE (atomic sliding window)
- Key format: `ratelimit:middleware:<ip>:<route-prefix>`
- Fail-open: if Redis unreachable, requests pass through
- runtime set to `nodejs` so ioredis works (Edge Runtime incompatible)
- Updated middleware tests

Closes #298