### PR TITLE
fix: add 2-day timelock to DaoDeGenJar.setBurnAmount() (#303)

### DIFF
--- a/packages/contracts/src/DaoDeGenJar.sol
+++ b/packages/contracts/src/DaoDeGenJar.sol
@@ -32,12 +32,25 @@ contract DaoDeGenJar is Ownable, ReentrancyGuard, Pausable {
     ///      See GasBenchmark.t.sol for measured values.
     uint256 public constant MAX_ASSETS = 10;
 
+    /// @notice Timelock delay for burn-amount changes.
+    uint256 public constant TIMELOCK_DELAY = 2 days;
+
+    /// @notice Timestamp when a burn-amount change was scheduled (0 = none pending).
+    uint256 public burnAmountScheduledAt;
+
+    /// @notice The burn amount that was scheduled.
+    uint256 public scheduledBurnAmount;
+
     error NothingToRelease();
     error Unauthorized();
     error TransferFailed();
     error DuplicateAsset();
     error TooManyAssets();
+    error NoBurnAmountScheduled();
+    error TimelockNotExpired();
 
+    event BurnAmountScheduled(uint256 newAmount, uint256 executeAfter);
+    event BurnAmountChangeCancelled(uint256 cancelledAmount);
     event FeesReleased(address indexed caller, uint256 burnAmount, uint256 nftHolders);
     event BurnAmountUpdated(uint256 newAmount);
     event Claimed(uint256 indexed tokenId, address indexed holder, Currency indexed asset, uint256 amount);
@@ -147,12 +160,32 @@ contract DaoDeGenJar is Ownable, ReentrancyGuard, Pausable {
         }
     }
 
-    /// @notice Update the burn amount required for release
-    /// @dev No timelock -- owner accepts frontrunning risk since burn amount
-    ///      changes are infrequent governance decisions, not price-sensitive.
-    function setBurnAmount(uint256 _burnAmount) external onlyOwner {
-        burnAmount = _burnAmount;
-        emit BurnAmountUpdated(_burnAmount);
+    /// @notice Schedule a burn-amount change. Requires a 2-day timelock.
+    /// @param _burnAmount The desired new burn amount.
+    function scheduleBurnAmount(uint256 _burnAmount) external onlyOwner {
+        burnAmountScheduledAt = block.timestamp;
+        scheduledBurnAmount = _burnAmount;
+        emit BurnAmountScheduled(_burnAmount, block.timestamp + TIMELOCK_DELAY);
+    }
+
+    /// @notice Execute a previously scheduled burn-amount change after the timelock.
+    function executeBurnAmount() external onlyOwner {
+        if (burnAmountScheduledAt == 0) revert NoBurnAmountScheduled();
+        if (block.timestamp < burnAmountScheduledAt + TIMELOCK_DELAY) revert TimelockNotExpired();
+
+        burnAmount = scheduledBurnAmount;
+        burnAmountScheduledAt = 0;
+        emit BurnAmountUpdated(scheduledBurnAmount);
+    }
+
+    /// @notice Cancel a pending burn-amount change.
+    function cancelBurnAmount() external onlyOwner {
+        if (burnAmountScheduledAt == 0) revert NoBurnAmountScheduled();
+
+        uint256 cancelled = scheduledBurnAmount;
+        burnAmountScheduledAt = 0;
+        scheduledBurnAmount = 0;
+        emit BurnAmountChangeCancelled(cancelled);
     }
 
     function pause() external onlyOwner { _pause(); }

--- a/packages/contracts/test/DaoDeGenJar.t.sol
+++ b/packages/contracts/test/DaoDeGenJar.t.sol
@@ -444,8 +444,10 @@ contract DaoDeGenJarTest is Test {
         (bool success,) = address(jar).call{value: 1 ether}("");
         require(success);
 
-        // Set burn amount to 0
-        jar.setBurnAmount(0);
+        // Schedule burn amount to 0 via timelock
+        jar.scheduleBurnAmount(0);
+        vm.warp(block.timestamp + 2 days);
+        jar.executeBurnAmount();
 
         Currency[] memory assets = new Currency[](1);
         assets[0] = CurrencyLibrary.ADDRESS_ZERO;
@@ -457,6 +459,77 @@ contract DaoDeGenJarTest is Test {
         assertEq(jar.claimable(1, assets[0]), 1 ether);
         // No tokens burned
         assertEq(token.balanceOf(user1), 1000e18);
+    }
+
+    // ── Burn-amount timelock tests ─────────────────────────────
+
+    function testScheduleBurnAmountEmitsEvent() public {
+        vm.expectEmit(false, false, false, true);
+        emit DaoDeGenJar.BurnAmountScheduled(200e18, block.timestamp + 2 days);
+        jar.scheduleBurnAmount(200e18);
+
+        assertEq(jar.scheduledBurnAmount(), 200e18);
+        assertEq(jar.burnAmountScheduledAt(), block.timestamp);
+    }
+
+    function testExecuteBurnAmountAfterTimelock() public {
+        jar.scheduleBurnAmount(200e18);
+        vm.warp(block.timestamp + 2 days);
+        jar.executeBurnAmount();
+
+        assertEq(jar.burnAmount(), 200e18);
+        assertEq(jar.burnAmountScheduledAt(), 0);
+    }
+
+    function testExecuteBurnAmountRevertsBeforeTimelock() public {
+        jar.scheduleBurnAmount(200e18);
+        vm.warp(block.timestamp + 2 days - 1);
+
+        vm.expectRevert(DaoDeGenJar.TimelockNotExpired.selector);
+        jar.executeBurnAmount();
+    }
+
+    function testExecuteBurnAmountRevertsWhenNoneScheduled() public {
+        vm.expectRevert(DaoDeGenJar.NoBurnAmountScheduled.selector);
+        jar.executeBurnAmount();
+    }
+
+    function testCancelBurnAmount() public {
+        jar.scheduleBurnAmount(200e18);
+        jar.cancelBurnAmount();
+
+        assertEq(jar.burnAmountScheduledAt(), 0);
+        assertEq(jar.scheduledBurnAmount(), 0);
+        // Original burn amount unchanged
+        assertEq(jar.burnAmount(), BURN_AMOUNT);
+    }
+
+    function testCancelBurnAmountRevertsWhenNoneScheduled() public {
+        vm.expectRevert(DaoDeGenJar.NoBurnAmountScheduled.selector);
+        jar.cancelBurnAmount();
+    }
+
+    function testScheduleBurnAmountOnlyOwner() public {
+        vm.prank(user1);
+        vm.expectRevert();
+        jar.scheduleBurnAmount(200e18);
+    }
+
+    function testExecuteBurnAmountOnlyOwner() public {
+        jar.scheduleBurnAmount(200e18);
+        vm.warp(block.timestamp + 2 days);
+
+        vm.prank(user1);
+        vm.expectRevert();
+        jar.executeBurnAmount();
+    }
+
+    function testCancelBurnAmountOnlyOwner() public {
+        jar.scheduleBurnAmount(200e18);
+
+        vm.prank(user1);
+        vm.expectRevert();
+        jar.cancelBurnAmount();
     }
 
     function testDustDistribution() public {

--- a/packages/contracts/test/EventsAndErrorsTest.t.sol
+++ b/packages/contracts/test/EventsAndErrorsTest.t.sol
@@ -28,10 +28,18 @@ contract EventsAndErrorsTest is Test {
 
     // --- DaoDeGenJar ---
 
-    function test_Jar_EmitsEventOnSetBurnAmount() public {
+    function test_Jar_EmitsEventOnScheduleBurnAmount() public {
+        vm.expectEmit(true, false, false, true);
+        emit DaoDeGenJar.BurnAmountScheduled(200, block.timestamp + 2 days);
+        jar.scheduleBurnAmount(200);
+    }
+
+    function test_Jar_EmitsEventOnExecuteBurnAmount() public {
+        jar.scheduleBurnAmount(200);
+        vm.warp(block.timestamp + 2 days);
         vm.expectEmit(true, false, false, true);
         emit BurnAmountUpdated(200);
-        jar.setBurnAmount(200);
+        jar.executeBurnAmount();
     }
 
     // --- VerseNFT ---

--- a/packages/contracts/test/PrayerBurn.t.sol
+++ b/packages/contracts/test/PrayerBurn.t.sol
@@ -342,7 +342,9 @@ contract PrayerBurnTest is Test {
         require(ok);
 
         // Set jar burn amount to 0 so PrayerBurn doesn't need tokens for release
-        jar.setBurnAmount(0);
+        jar.scheduleBurnAmount(0);
+        vm.warp(block.timestamp + 2 days);
+        jar.executeBurnAmount();
 
         // Enable auto-release with 1 ether threshold
         prayer.setReleaseThreshold(1 ether);
@@ -412,7 +414,9 @@ contract PrayerBurnTest is Test {
 
     function testAutoReleaseSkippedBelowThreshold() public {
         nft.ownerMint(user1, 1);
-        jar.setBurnAmount(0);
+        jar.scheduleBurnAmount(0);
+        vm.warp(block.timestamp + 2 days);
+        jar.executeBurnAmount();
 
         // Fund jar with only 0.5 ether (below 1 ether threshold)
         (bool ok,) = address(jar).call{value: 0.5 ether}("");


### PR DESCRIPTION
## Problem
Owner could instantly change the burn amount required for `release()`, surprising NFT holders with no notice.

## Fix
Following the same pattern as DaoDeGenHook pause timelock:
- `scheduleBurnAmount(uint256)` — records intent + timestamp, emits event
- `executeBurnAmount()` — executes after 2-day delay
- `cancelBurnAmount()` — lets owner cancel pending change
- 24 tests passing ✅

Closes #303