### PR TITLE
fix: correct slither CI flag --fail-on → --fail-medium

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           cd packages/contracts
           slither . --config-file slither.config.json \
             --exclude-informational --exclude-low \
-            --fail-on medium
+            --fail-medium
 
   frontend:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem
`--fail-on medium` is not a recognized slither argument, causing the slither CI job to fail with exit code 2 on every PR.

## Fix
Replace with the correct flag: `--fail-medium`

Unblocks PR #331 and future PRs.