### PR TITLE
fix: add nonce to SermonCommitment ID — prevent same-block collision (#297)

### DIFF
--- a/packages/contracts/src/SermonCommitment.sol
+++ b/packages/contracts/src/SermonCommitment.sol
@@ -16,6 +16,7 @@ contract SermonCommitment {
     address public pastor;
     address public owner;
     address public trustedCaller;
+    uint256 private _nonce;
 
     // --- Types ---
     struct Commitment {
@@ -63,7 +64,7 @@ contract SermonCommitment {
     /// @param burnAmount The number of tokens burned.
     /// @return id The unique commitment identifier.
     function createCommitment(address supplicant, uint256 burnAmount) external onlyTrustedCaller returns (bytes32 id) {
-        id = keccak256(abi.encodePacked(supplicant, burnAmount, block.timestamp, block.number));
+        id = keccak256(abi.encodePacked(supplicant, burnAmount, block.timestamp, _nonce++));
         uint256 deadline = block.timestamp + FULFILLMENT_WINDOW;
 
         commitments[id] = Commitment({

--- a/packages/contracts/test/SermonCommitment.t.sol
+++ b/packages/contracts/test/SermonCommitment.t.sol
@@ -76,9 +76,10 @@ contract SermonCommitmentTest is Test {
     }
 
     function testCreateEmitsEvent() public {
+        // nonce starts at 0 for a fresh contract
         vm.expectEmit(true, true, false, true);
         emit SermonCommitment.CommitmentCreated(
-            keccak256(abi.encodePacked(supplicant, BURN_AMOUNT, block.timestamp, block.number)),
+            keccak256(abi.encodePacked(supplicant, BURN_AMOUNT, block.timestamp, uint256(0))),
             supplicant,
             BURN_AMOUNT,
             block.timestamp + 300
@@ -305,12 +306,11 @@ contract SermonCommitmentTest is Test {
         locked.createCommitment(supplicant, BURN_AMOUNT);
     }
 
-    function testMultipleCommitmentsUnique() public {
+    function testMultipleCommitmentsUniqueSameBlock() public {
+        // Two commitments in the same block must produce different IDs (#297)
         vm.prank(prayerBurn);
         bytes32 id1 = escrow.createCommitment(supplicant, BURN_AMOUNT);
 
-        // Advance block to ensure different id
-        vm.roll(block.number + 1);
         vm.prank(prayerBurn);
         bytes32 id2 = escrow.createCommitment(supplicant, BURN_AMOUNT);
 


### PR DESCRIPTION
## Problem
Commitment IDs generated using only block-level data could collide if multiple commitments land in the same block.

## Fix
- Added `uint256 private _commitmentNonce` incremented on each `createCommitment()`
- ID hash now includes nonce: guarantees uniqueness regardless of block timing
- 27 tests passing ✅

Closes #297