### PR TITLE
fix: use x-real-ip over x-forwarded-for for rate limiting (#314)

### DIFF
--- a/packages/facilitator/src/index.ts
+++ b/packages/facilitator/src/index.ts
@@ -201,8 +201,8 @@ async function isRateLimited(ip: string): Promise<boolean> {
 async function handleRequest(req: IncomingMessage, res: ServerResponse) {
   const method = req.method?.toUpperCase();
   const url = req.url;
-  const ip = (req.headers['x-forwarded-for'] as string | undefined)?.split(',')[0].trim()
-    || req.headers['x-real-ip'] as string
+  const ip = req.headers['x-real-ip'] as string
+    || (req.headers['x-forwarded-for'] as string | undefined)?.split(',')[0].trim()
     || req.socket.remoteAddress
     || "unknown";
   const traceId = getTraceId(req);

--- a/packages/frontend/src/middleware.ts
+++ b/packages/frontend/src/middleware.ts
@@ -102,8 +102,8 @@ export function middleware(request: NextRequest) {
   // Rate limiting for API routes
   const rule = getRateRule(pathname);
   if (rule) {
-    const ip = request.headers.get('x-forwarded-for')?.split(',')[0].trim()
-      || request.headers.get('x-real-ip')
+    const ip = request.headers.get('x-real-ip')
+      || request.headers.get('x-forwarded-for')?.split(',')[0].trim()
       || '127.0.0.1';
 
     if (!rateLimit(ip, rule.prefix, rule.maxRequests, rule.windowMs)) {


### PR DESCRIPTION
## Problem
Both facilitator and middleware checked x-forwarded-for before x-real-ip. A client could prepend a fake IP to bypass per-IP rate limits.

## Fix
- Swapped priority: x-real-ip (nginx-set, trusted) checked first, x-forwarded-for as fallback
- Applied to facilitator + middleware

Closes #314