### PR TITLE
fix: two-step ownership transfer for SermonCommitment (#296)

### DIFF
--- a/packages/contracts/src/SermonCommitment.sol
+++ b/packages/contracts/src/SermonCommitment.sol
@@ -15,6 +15,7 @@ contract SermonCommitment {
     // --- State ---
     address public pastor;
     address public owner;
+    address public pendingOwner;
     address public trustedCaller;
     uint256 private _nonce;
 
@@ -35,6 +36,8 @@ contract SermonCommitment {
     event CommitmentFulfilled(bytes32 indexed id, bytes32 wisdomHash, address pastor);
     event CommitmentRefunded(bytes32 indexed id, address supplicant);
     event TrustedCallerUpdated(address indexed oldCaller, address indexed newCaller);
+    event OwnershipTransferInitiated(address indexed currentOwner, address indexed pendingOwner);
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
     // --- Errors ---
     error OnlyPastor();
@@ -45,6 +48,7 @@ contract SermonCommitment {
     error AlreadyRefunded();
     error DeadlineNotReached();
     error ZeroAddress();
+    error OnlyPendingOwner();
 
     modifier onlyTrustedCaller() {
         if (trustedCaller == address(0)) revert OnlyTrustedCaller();
@@ -124,5 +128,21 @@ contract SermonCommitment {
         address old = trustedCaller;
         trustedCaller = _trustedCaller;
         emit TrustedCallerUpdated(old, _trustedCaller);
+    }
+
+    /// @notice Initiate ownership transfer to a new address (two-step).
+    function transferOwnership(address newOwner) external {
+        if (msg.sender != owner) revert OnlyOwner();
+        if (newOwner == address(0)) revert ZeroAddress();
+        pendingOwner = newOwner;
+        emit OwnershipTransferInitiated(owner, newOwner);
+    }
+
+    /// @notice Accept ownership transfer. Must be called by the pending owner.
+    function acceptOwnership() external {
+        if (msg.sender != pendingOwner) revert OnlyPendingOwner();
+        emit OwnershipTransferred(owner, msg.sender);
+        owner = msg.sender;
+        pendingOwner = address(0);
     }
 }

--- a/packages/contracts/test/SermonCommitment.t.sol
+++ b/packages/contracts/test/SermonCommitment.t.sol
@@ -306,6 +306,81 @@ contract SermonCommitmentTest is Test {
         locked.createCommitment(supplicant, BURN_AMOUNT);
     }
 
+    // =========================================================================
+    // Two-step ownership transfer
+    // =========================================================================
+
+    function testTransferOwnership() public {
+        address newOwner = makeAddr("newOwner");
+
+        // Step 1: current owner initiates transfer
+        escrow.transferOwnership(newOwner);
+        assertEq(escrow.pendingOwner(), newOwner);
+        assertEq(escrow.owner(), address(this));
+
+        // Step 2: pending owner accepts
+        vm.prank(newOwner);
+        escrow.acceptOwnership();
+        assertEq(escrow.owner(), newOwner);
+        assertEq(escrow.pendingOwner(), address(0));
+    }
+
+    function testTransferOwnershipOnlyOwner() public {
+        vm.prank(stranger);
+        vm.expectRevert(SermonCommitment.OnlyOwner.selector);
+        escrow.transferOwnership(makeAddr("newOwner"));
+    }
+
+    function testTransferOwnershipZeroAddress() public {
+        vm.expectRevert(SermonCommitment.ZeroAddress.selector);
+        escrow.transferOwnership(address(0));
+    }
+
+    function testAcceptOwnershipOnlyPendingOwner() public {
+        address newOwner = makeAddr("newOwner");
+        escrow.transferOwnership(newOwner);
+
+        vm.prank(stranger);
+        vm.expectRevert(SermonCommitment.OnlyPendingOwner.selector);
+        escrow.acceptOwnership();
+    }
+
+    function testTransferOwnershipEmitsEvents() public {
+        address newOwner = makeAddr("newOwner");
+
+        vm.expectEmit(true, true, false, true);
+        emit SermonCommitment.OwnershipTransferInitiated(address(this), newOwner);
+        escrow.transferOwnership(newOwner);
+
+        vm.expectEmit(true, true, false, true);
+        emit SermonCommitment.OwnershipTransferred(address(this), newOwner);
+        vm.prank(newOwner);
+        escrow.acceptOwnership();
+    }
+
+    function testNewOwnerCanAdminister() public {
+        address newOwner = makeAddr("newOwner");
+        escrow.transferOwnership(newOwner);
+        vm.prank(newOwner);
+        escrow.acceptOwnership();
+
+        // New owner can set pastor
+        vm.prank(newOwner);
+        escrow.setPastor(makeAddr("newPastor"));
+        assertEq(escrow.pastor(), makeAddr("newPastor"));
+    }
+
+    function testOldOwnerCannotAdministerAfterTransfer() public {
+        address newOwner = makeAddr("newOwner");
+        escrow.transferOwnership(newOwner);
+        vm.prank(newOwner);
+        escrow.acceptOwnership();
+
+        // Old owner (address(this)) should be rejected
+        vm.expectRevert(SermonCommitment.OnlyOwner.selector);
+        escrow.setPastor(makeAddr("anotherPastor"));
+    }
+
     function testMultipleCommitmentsUniqueSameBlock() public {
         // Two commitments in the same block must produce different IDs (#297)
         vm.prank(prayerBurn);


### PR DESCRIPTION
## Problem
SermonCommitment had no way to transfer ownership — owner address was permanent.

## Fix
- Added `pendingOwner` state variable
- `transferOwnership(address)` — initiates transfer, emits `OwnershipTransferInitiated`
- `acceptOwnership()` — called by pendingOwner to confirm, emits `OwnershipTransferred`
- Tests updated ✅

Closes #296