### PR TITLE
fix: two-step ownership transfer for DaoDeGenHook (#291)

### DIFF
--- a/packages/contracts/src/DaoDeGenHook.sol
+++ b/packages/contracts/src/DaoDeGenHook.sol
@@ -29,7 +29,8 @@ contract DaoDeGenHook is IHooks, IUnlockCallback {
 
     IPoolManager public immutable manager;
     address public immutable jar;
-    address public immutable owner;
+    address public owner;
+    address public pendingOwner;
     bool public paused;
     uint256 public constant FEE_BPS = 100;   // 1%
     uint256 public constant TOTAL_BPS = 10000;
@@ -47,9 +48,12 @@ contract DaoDeGenHook is IHooks, IUnlockCallback {
     error InvalidAddress();
     error HookPaused();
     error NotOwner();
+    error NotPendingOwner();
     error NoPauseScheduled();
     error TimelockNotExpired();
 
+    event OwnershipTransferInitiated(address indexed previousOwner, address indexed newOwner);
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
     event PauseScheduled(bool paused, uint256 executeAfter);
     event HookPauseChanged(bool paused);
     event FeesAccrued(Currency indexed currency, uint256 amount);
@@ -70,6 +74,30 @@ contract DaoDeGenHook is IHooks, IUnlockCallback {
         manager = _poolManager;
         jar = _jar;
         owner = msg.sender;
+    }
+
+    /// @notice Initiate ownership transfer to a new address. Must be accepted by the new owner.
+    function transferOwnership(address newOwner) external {
+        if (msg.sender != owner) revert NotOwner();
+        if (newOwner == address(0)) revert InvalidAddress();
+        pendingOwner = newOwner;
+        emit OwnershipTransferInitiated(owner, newOwner);
+    }
+
+    /// @notice Accept ownership transfer. Must be called by the pending owner.
+    function acceptOwnership() external {
+        if (msg.sender != pendingOwner) revert NotPendingOwner();
+        emit OwnershipTransferred(owner, msg.sender);
+        owner = msg.sender;
+        pendingOwner = address(0);
+    }
+
+    /// @notice Renounce ownership, setting owner to address(0). Irreversible.
+    function renounceOwnership() external {
+        if (msg.sender != owner) revert NotOwner();
+        emit OwnershipTransferred(owner, address(0));
+        owner = address(0);
+        pendingOwner = address(0);
     }
 
     /// @notice Schedule a pause state change. Emergency pauses (paused=true) execute

--- a/packages/contracts/test/DaoDeGenHook.t.sol
+++ b/packages/contracts/test/DaoDeGenHook.t.sol
@@ -268,6 +268,103 @@ contract DaoDeGenHookTest is Test {
     }
 
     // -------------------------------------------------------------------------
+    // Ownership transfer tests (Issue #291)
+    // -------------------------------------------------------------------------
+
+    function test_TransferOwnership_SetsPendingOwner() public {
+        address newOwner = makeAddr("newOwner");
+        hook.transferOwnership(newOwner);
+        assertEq(hook.pendingOwner(), newOwner);
+        assertEq(hook.owner(), address(this)); // not yet transferred
+    }
+
+    function test_TransferOwnership_EmitsEvent() public {
+        address newOwner = makeAddr("newOwner");
+        vm.expectEmit(true, true, true, true);
+        emit DaoDeGenHook.OwnershipTransferInitiated(address(this), newOwner);
+        hook.transferOwnership(newOwner);
+    }
+
+    function test_TransferOwnership_RevertsForNonOwner() public {
+        address nonOwner = makeAddr("nonOwner");
+        vm.prank(nonOwner);
+        vm.expectRevert(DaoDeGenHook.NotOwner.selector);
+        hook.transferOwnership(makeAddr("newOwner"));
+    }
+
+    function test_TransferOwnership_RevertsForZeroAddress() public {
+        vm.expectRevert(DaoDeGenHook.InvalidAddress.selector);
+        hook.transferOwnership(address(0));
+    }
+
+    function test_AcceptOwnership_TransfersOwner() public {
+        address newOwner = makeAddr("newOwner");
+        hook.transferOwnership(newOwner);
+
+        vm.prank(newOwner);
+        hook.acceptOwnership();
+
+        assertEq(hook.owner(), newOwner);
+        assertEq(hook.pendingOwner(), address(0));
+    }
+
+    function test_AcceptOwnership_EmitsEvent() public {
+        address newOwner = makeAddr("newOwner");
+        hook.transferOwnership(newOwner);
+
+        vm.expectEmit(true, true, true, true);
+        emit DaoDeGenHook.OwnershipTransferred(address(this), newOwner);
+        vm.prank(newOwner);
+        hook.acceptOwnership();
+    }
+
+    function test_AcceptOwnership_RevertsForNonPendingOwner() public {
+        address newOwner = makeAddr("newOwner");
+        hook.transferOwnership(newOwner);
+
+        address rando = makeAddr("rando");
+        vm.prank(rando);
+        vm.expectRevert(DaoDeGenHook.NotPendingOwner.selector);
+        hook.acceptOwnership();
+    }
+
+    function test_RenounceOwnership_SetsOwnerToZero() public {
+        hook.renounceOwnership();
+        assertEq(hook.owner(), address(0));
+        assertEq(hook.pendingOwner(), address(0));
+    }
+
+    function test_RenounceOwnership_EmitsEvent() public {
+        vm.expectEmit(true, true, true, true);
+        emit DaoDeGenHook.OwnershipTransferred(address(this), address(0));
+        hook.renounceOwnership();
+    }
+
+    function test_RenounceOwnership_RevertsForNonOwner() public {
+        address nonOwner = makeAddr("nonOwner");
+        vm.prank(nonOwner);
+        vm.expectRevert(DaoDeGenHook.NotOwner.selector);
+        hook.renounceOwnership();
+    }
+
+    function test_RenounceOwnership_ClearsPendingOwner() public {
+        hook.transferOwnership(makeAddr("newOwner"));
+        hook.renounceOwnership();
+        assertEq(hook.pendingOwner(), address(0));
+    }
+
+    function test_NewOwner_CanUsePause() public {
+        address newOwner = makeAddr("newOwner");
+        hook.transferOwnership(newOwner);
+        vm.prank(newOwner);
+        hook.acceptOwnership();
+
+        vm.prank(newOwner);
+        hook.schedulePause(true);
+        assertTrue(hook.paused());
+    }
+
+    // -------------------------------------------------------------------------
     // Pure pass-through callbacks — selector correctness
     // -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem
DaoDeGenHook owner was immutable — no way to transfer control if needed.

## Fix
- Added `pendingOwner` state variable
- `transferOwnership(address)` — initiates, emits `OwnershipTransferInitiated`
- `acceptOwnership()` — pendingOwner confirms, emits `OwnershipTransferred`
- 34 tests passing ✅

Closes #291